### PR TITLE
fix: update logic for determining network-operator base branch for values update PR

### DIFF
--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -20,13 +20,13 @@ jobs:
       - if: github.ref_type == 'branch'
         name: Determine docker registry and tag (when git branch)
         run: |
-          echo DOCKER_REGISTRY=$REGISTRY_INTERNAL >> $GITHUB_ENV
-          echo DOCKER_TAG=$(git rev-parse --short HEAD) >> $GITHUB_ENV  # short git commit hash
+          echo DOCKER_REGISTRY=$REGISTRY_INTERNAL | tee -a $GITHUB_ENV
+          echo DOCKER_TAG=$(git rev-parse --short HEAD) | tee -a $GITHUB_ENV  # short git commit hash
       - if: github.ref_type == 'tag'
         name: Determine docker registry and tag (when git tag)
         run: |
-          echo DOCKER_REGISTRY=$(echo ${{ github.ref_name }} | sed 's/network-operator-//' | grep -q '-' && echo $REGISTRY_INTERNAL || echo $REGISTRY_PUBLIC) >> $GITHUB_ENV  # use public registry only when release tag has no '-beta*' or '-rc*' suffix
-          echo DOCKER_TAG=${{ github.ref_name }} >> $GITHUB_ENV
+          echo DOCKER_REGISTRY=$(echo ${{ github.ref_name }} | sed 's/network-operator-//' | grep -q '-' && echo $REGISTRY_INTERNAL || echo $REGISTRY_PUBLIC) | tee -a $GITHUB_ENV  # use public registry only when release tag has no '-beta*' or '-rc*' suffix
+          echo DOCKER_TAG=${{ github.ref_name }} | tee -a $GITHUB_ENV
       - name: Store docker registry and tag for following jobs
         id: store-docker-registry-and-tag
         run: |
@@ -92,7 +92,12 @@ jobs:
           path: network-opertor-fork
       - name: Determine base branch
         run: |
-          echo "BASE_BRANCH=${{ contains(env.DOCKER_TAG, 'beta') && 'master' || env.DOCKER_TAG }}" >> $GITHUB_ENV
+          if [[ "${{ github.ref_type }}" == "branch" || "${{ github.ref_name }}" == *"beta"* ]]; then  # branch commits and beta tags update values on network-operator's *master* branch
+            echo BASE_BRANCH=master | tee -a $GITHUB_ENV
+          else  # GA and `-rc.` tags update values on network-operator's respective *release* branches
+            release_branch=$(echo ${{ github.ref_name }} | sed -E 's/^network-operator-([0-9]+\.[0-9]+).+/v\1.x/')  # example: transforms "network-operator-25.1.0-beta.2" to "v25.1.x"
+            echo BASE_BRANCH=$release_branch | tee -a $GITHUB_ENV
+          fi
       - name: Create PR to update image tags in network-operator values
         run: |
           cd network-opertor-fork
@@ -102,18 +107,18 @@ jobs:
 
           git checkout -b feature/update-sriov-tags-to-$DOCKER_TAG
 
-          # NOTE: ignore Chart.yaml changes because we refer to chart name in values.yaml and have hardcoded version.
-          cp -r ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/crds/ deployment/network-operator/charts/sriov-network-operator/
-          cp -r ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/templates/ deployment/network-operator/charts/sriov-network-operator/
-          cp  ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/README.md deployment/network-operator/charts/sriov-network-operator/
-          cp  ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/values.yaml deployment/network-operator/charts/sriov-network-operator/
+          # we *don't* copy `Chart.yaml` with the files below, because network-operator's `Chart.yaml` refers to the SR-IOV chart name with a hardcoded version.
+          cp -r ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/crds/       deployment/network-operator/charts/sriov-network-operator/
+          cp -r ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/templates/  deployment/network-operator/charts/sriov-network-operator/
+          cp    ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/README.md   deployment/network-operator/charts/sriov-network-operator/
+          cp    ../sriov-network-operator-fork/deployment/sriov-network-operator-chart/values.yaml deployment/network-operator/charts/sriov-network-operator/
 
-          yq -i e '.SriovNetworkOperator.repository |= "${{ env.DOCKER_REGISTRY }}"' hack/release.yaml
-          yq -i e '.SriovNetworkOperator.version |= "${{ env.DOCKER_TAG }}"' hack/release.yaml
-          yq -i e '.SriovConfigDaemon.repository |= "${{ env.DOCKER_REGISTRY }}"' hack/release.yaml
-          yq -i e '.SriovConfigDaemon.version |= "${{ env.DOCKER_TAG }}"' hack/release.yaml
-          yq -i e '.SriovNetworkOperatorWebhook.repository |= "${{ env.DOCKER_REGISTRY }}"' hack/release.yaml
-          yq -i e '.SriovNetworkOperatorWebhook.version |= "${{ env.DOCKER_TAG }}"' hack/release.yaml
+          yq -i '.SriovNetworkOperator.repository = "${{ env.DOCKER_REGISTRY }}"'        hack/release.yaml
+          yq -i '.SriovNetworkOperator.version = "${{ env.DOCKER_TAG }}"'                hack/release.yaml
+          yq -i '.SriovConfigDaemon.repository = "${{ env.DOCKER_REGISTRY }}"'           hack/release.yaml
+          yq -i '.SriovConfigDaemon.version = "${{ env.DOCKER_TAG }}"'                   hack/release.yaml
+          yq -i '.SriovNetworkOperatorWebhook.repository = "${{ env.DOCKER_REGISTRY }}"' hack/release.yaml
+          yq -i '.SriovNetworkOperatorWebhook.version = "${{ env.DOCKER_TAG }}"'         hack/release.yaml
           make release-build
 
           if ! git diff --color --unified=0 --exit-code; then


### PR DESCRIPTION
pseudo logic:
```python
if github.ref_type == 'branch' or github.ref_name.contains('beta'):   # branch commits and beta tags update values on network-operator's *master* branch
  BASE_BRANCH = 'master'
else:   # GA and `-rc.` tags update values on network-operator's respective *release* branches
  BASE_BRANCH = release_branch
```

additional changes:
- `e[val]` is the default behavior of `yq`, no need to set it.
- spacing for readability.
- `tee -a` sets `GITHUB_ENV` variables while also printing them to log for clarity.