### PR TITLE
ci: PR for Network Operator base branch

### DIFF
--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -85,11 +85,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: sriov-network-operator-fork
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
-          repository: ${{ github.repository_owner }}/network-operator
-          path: network-opertor-fork
       - name: Determine base branch
         run: |
           if [[ "${{ github.ref_type }}" == "branch" || "${{ github.ref_name }}" == *"beta"* ]]; then  # branch commits and beta tags update values on network-operator's *master* branch
@@ -98,9 +93,15 @@ jobs:
             release_branch=$(echo ${{ github.ref_name }} | sed -E 's/^network-operator-([0-9]+\.[0-9]+).+/v\1.x/')  # example: transforms "network-operator-25.1.0-beta.2" to "v25.1.x"
             echo BASE_BRANCH=$release_branch | tee -a $GITHUB_ENV
           fi
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
+          repository: ${{ github.repository_owner }}/network-operator
+          path: network-operator-fork
+          ref: ${{ env.BASE_BRANCH }}
       - name: Create PR to update image tags in network-operator values
         run: |
-          cd network-opertor-fork
+          cd network-operator-fork
 
           git config user.name  nvidia-ci-cd
           git config user.email svc-cloud-orch-gh@nvidia.com


### PR DESCRIPTION
The CI PR sent to update the SRIOV-Network Operator versions should be based on the BASE_BRANCH

Backport of #55 