### PR TITLE
fix: add missing slash into a path constant

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -155,7 +155,7 @@ const (
 
 	SriovServiceBasePath        = "/etc/systemd/system"
 	SriovServicePath            = SriovServiceBasePath + "/sriov-config.service"
-	SriovPostNetworkServicePath = SriovServiceBasePath + "sriov-config-post-network.service"
+	SriovPostNetworkServicePath = SriovServiceBasePath + "/sriov-config-post-network.service"
 
 	// Feature gates
 	// ParallelNicConfigFeatureGate: allow to configure nics in parallel


### PR DESCRIPTION
The missing slash led to the post-network systemd service not being looked up, which in turn led to the reboot loop on the node


(cherry picked from commit 14c4c035cc530dcc854294ce1da2aa724fc17e8d)