### PR TITLE
fix: correct kargs.sh script path

### DIFF
--- a/pkg/host/internal/network/network.go
+++ b/pkg/host/internal/network/network.go
@@ -442,6 +442,9 @@ func (n *network) DiscoverRDMASubsystem() (string, error) {
 func (n *network) SetRDMASubsystem(mode string) error {
 	log.Log.Info("SetRDMASubsystem(): Updating RDMA subsystem mode", "mode", mode)
 	path := filepath.Join(vars.FilesystemRoot, consts.Host, "etc", "modprobe.d", "sriov_network_operator_modules_config.conf")
+	if _, err := os.Stat(consts.Host); errors.Is(err, os.ErrNotExist) {
+		path = filepath.Join(vars.FilesystemRoot, "/etc", "modprobe.d", "sriov_network_operator_modules_config.conf")
+	}
 
 	if mode == "" {
 		err := os.Remove(path)

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"errors"
 	"fmt"
+	"os"
 	"syscall"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -271,7 +272,7 @@ func needDriverCheckVdpaType(state *sriovnetworkv1.SriovNetworkNodeState, driver
 func editKernelArg(helper helper.HostHelpersInterface, mode, karg string) error {
 	log.Log.Info("generic plugin editKernelArg()", "mode", mode, "karg", karg)
 	script := daemonScriptsPath
-	if vars.UsingSystemdMode {
+	if _, err := os.Stat(consts.Host); errors.Is(err, os.ErrNotExist) {
 		script = systemdScriptsPath
 	}
 	_, _, err := helper.RunCommand("/bin/bash", script, mode, karg)


### PR DESCRIPTION
We can't relay on vars.UsingSystemdMode variable because we execute this from deamon even in a systemd mode.

We need to re-risit logic to not call this script twice