### PR TITLE
Support node draining by external NVIDIA maintenance OP

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ nodes in parallel from the pool the operator can drain in parallel. maxUnavailab
 
 > **NOTE**: If a node is not part of any pool it will have a default configuration of maxUnavailable 1
 
+> **NOTE**: Internal drain controller can be disabled by exposing the following `USE_MAINTENANCE_OPERATOR_DRAINER` env variable. This means that drain operations will be done externally, utilizing [NVIDIA maintenance OP](https://github.com/Mellanox/maintenance-operator). In addition, `SriovNetworkPoolConfig` will not take any effect during drain procedure, since the maintenance operator will be in charge of [parallel node operations](https://github.com/Mellanox/maintenance-operator/blob/main/api/v1alpha1/maintenanceoperatorconfig_types.go#L38-L46).
 
 #### RDMA Mode Configuration
 

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -138,6 +138,12 @@ func GetImagePullSecrets() []string {
 	}
 }
 
+// UseMaintenanceOperatorDrainer indicates if internal drain controller is disabled
+// and draining will be done by external NVIDIA maintenance operator
+func UseMaintenanceOperatorDrainer() bool {
+	return os.Getenv("USE_MAINTENANCE_OPERATOR_DRAINER") == "true"
+}
+
 func formatJSON(str string) (string, error) {
 	var prettyJSON bytes.Buffer
 	if err := json.Indent(&prettyJSON, []byte(str), "", "    "); err != nil {

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -78,6 +78,8 @@ spec:
               value: {{ .Values.operator.metricsExporter.certificates.secretName }}
             - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
               value: {{ .Values.images.metricsExporterKubeRbacProxy }}
+            - name: USE_MAINTENANCE_OPERATOR_DRAINER
+              value: {{ .Values.operator.maintenanceOperatorDrainer.enabled | quote }}
             {{- if .Values.operator.metricsExporter.prometheusOperator.enabled }}
             - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
               value: {{ .Values.operator.metricsExporter.prometheusOperator.enabled | quote}}

--- a/deployment/sriov-network-operator-chart/values.yaml
+++ b/deployment/sriov-network-operator-chart/values.yaml
@@ -40,6 +40,9 @@ operator:
       serviceAccount: "prometheus-k8s"
       namespace: "monitoring"
       deployRules: false
+  # use external drain controller, utilizing NVIDIA maintenance operator
+  maintenanceOperatorDrainer:
+    enabled: false
   admissionControllers:
     enabled: false
     certificates:

--- a/doc/design/parallel-node-config.md
+++ b/doc/design/parallel-node-config.md
@@ -60,6 +60,8 @@ Node annotation, `sriovnetwork.openshift.io/state` and SriovNetworkNodeState ann
 
 *NOTE:* In the future we are going to drop the node annotation and only use the SriovNetworkNodeState
 
+*NOTE:* Internal drain controller can be disabled by exposing the following `USE_MAINTENANCE_OPERATOR_DRAINER` env variable. This means that drain operations will be done externally, utilizing [NVIDIA maintenance OP](https://github.com/Mellanox/maintenance-operator). In addition, `SriovNetworkPoolConfig` will not take any effect during drain procedure, since the maintenance operator will be in charge of parallel node operations.
+
 Draining procedure:
 
 1. config daemon mark the node as `Drain_Required` or `Reboot_Required` by adding that to both the Node annotation, `sriovnetwork.openshift.io/state`


### PR DESCRIPTION
SRIOV OP internal drain controller can be disabled, through USE_MAINTENANCE_OPERATOR_DRAINER, and draining will be performed by external [NVIDIA maintenance operator](https://github.com/Mellanox/maintenance-operator)

Cherry-picked from upstream [#952](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/952)