### PR TITLE
chore: use MFT package instead of mstflint

### DIFF
--- a/Dockerfile.sriov-network-config-daemon-stig
+++ b/Dockerfile.sriov-network-config-daemon-stig
@@ -4,10 +4,24 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM nvcr.io/nvstaging/mellanox/ubuntu-pro-stig:24.04
-ARG MSTFLINT=mstflint
-# We have to ensure that pciutils is installed. This package is needed for mstfwreset to succeed.
+# We have to ensure that pciutils and dkms are installed. These packages are needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN apt update && apt -y install hwdata pciutils mstflint
+RUN apt update && apt -y install hwdata pciutils curl dkms
+
+ARG TARGETARCH
+ENV MFT_VERSION=4.33.0-169
+RUN case ${TARGETARCH} in \
+        amd64) ARCH=x86_64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-${ARCH}-deb.tgz | tar -xz -C /tmp && \
+    cd /tmp/mft-${MFT_VERSION}-${ARCH}-deb && \
+    ./install.sh --without-kernel
+
+RUN ln -s $(which mlxconfig) /usr/bin/mstconfig
+RUN ln -s $(which mlxfwreset) /usr/bin/mstfwreset
+
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/

--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -26,10 +26,24 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM ${BASE_IMAGE_DOCA_BASE_RT_HOST:-nvcr.io/nvidia/doca/doca:3.1.0-base-rt-host}
-ARG MSTFLINT=mstflint
-# We have to ensure that pciutils is installed. This package is needed for mstfwreset to succeed.
+# We have to ensure that pciutils and dkms are installed. These packages are needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && apt-get update && apt-get install -y hwdata pciutils $ARCH_DEP_PKGS && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y hwdata pciutils curl dkms && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ARG TARGETARCH
+ENV MFT_VERSION=4.33.0-169
+RUN case ${TARGETARCH} in \
+        amd64) ARCH=x86_64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-${ARCH}-deb.tgz | tar -xz -C /tmp && \
+    cd /tmp/mft-${MFT_VERSION}-${ARCH}-deb && \
+    ./install.sh --without-kernel
+
+RUN ln -s $(which mlxconfig) /usr/bin/mstconfig
+RUN ln -s $(which mlxfwreset) /usr/bin/mstfwreset
+
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/


### PR DESCRIPTION
mstflint version, distributed with Ubuntu 24.04 is too old for some CX8 SKUs and cannot work with them.
Install MFT package of the relevant version and create symlinks not to break the existing code.