### PR TITLE
chore: Remove dkms package

### DIFF
--- a/Dockerfile.sriov-network-config-daemon-stig
+++ b/Dockerfile.sriov-network-config-daemon-stig
@@ -4,9 +4,9 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM nvcr.io/nvstaging/mellanox/ubuntu-pro-stig:24.04
-# We have to ensure that pciutils and dkms are installed. These packages are needed for mstfwreset to succeed.
+# We have to ensure that pciutils is installed. These packages are needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN apt update && apt -y install hwdata pciutils curl dkms
+RUN apt update && apt -y install hwdata pciutils curl
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.33.0-169

--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -26,9 +26,9 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM ${BASE_IMAGE_DOCA_BASE_RT_HOST:-nvcr.io/nvidia/doca/doca:3.1.0-base-rt-host}
-# We have to ensure that pciutils and dkms are installed. These packages are needed for mstfwreset to succeed.
+# We have to ensure that pciutils is installed. These packages are needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN apt-get update && apt-get install -y hwdata pciutils curl dkms && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y hwdata pciutils curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.33.0-169


### PR DESCRIPTION
We intall MFT package with `--without-kernel` flag so dkms package isn't needed.