### PR TITLE
ci: fail pulse scans on technical errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,7 +211,8 @@ pulse-scan-oss:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$DOCKER_IMAGE_NAME:$DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true  # non gating (pipeline stages will display warnings instead of failures)
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline
 
 pulse-scan-stig:
   stage: pulse-scan-stig
@@ -234,4 +235,5 @@ pulse-scan-stig:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$DOCKER_IMAGE_NAME:$DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true  # non gating (pipeline stages will display warnings instead of failures)
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline


### PR DESCRIPTION
Replace `allow_failure: true` with `allow_failure: exit_codes: [11, 255]` so scan policy violations remain non-gating (yellow) while technical failures (e.g. sso auth error → exit 1, nspect id not found → exit 2) fail the pipeline (red).