### PR TITLE
chore: eliminate usage of busybox in ovs-cni and use GO entrypoint

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -90,12 +90,11 @@ spec:
         {{- if .OVSCNIImage }}
         - name: ovs-cni
           image: {{.OVSCNIImage}}
-          command: ["/bin/sh","-c"]
           args:
-            - >
-              cp /ovs /host/opt/cni/bin/ovs &&
-              cp /ovs-mirror-producer /host/opt/cni/bin/ovs-mirror-producer &&
-              cp /ovs-mirror-consumer /host/opt/cni/bin/ovs-mirror-consumer
+            - --cni-bin-dir=/host/opt/cni/bin
+            - --ovs-bin-file=/ovs
+            - --ovs-mirror-producer-bin-file=/ovs-mirror-producer
+            - --ovs-mirror-consumer-bin-file=/ovs-mirror-consumer
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
According to new ovs-cni entrypoint:
```
entrypoint -h
This is an entrypoint script for OVS CNI to overlay its
binaries into location in a filesystem. Binary files will
be copied to the corresponding CNI bin directory.

./entrypoint
	-h --help
	--cni-bin-dir=/host/opt/cni/bin
	--ovs-bin-file=/usr/bin/ovs
	--ovs-mirror-producer-bin-file=ovs-mirror-producer
	--ovs-mirror-consumer-bin-file=ovs-mirror-consumer
```