### PR TITLE
feat: allow user-supplied flow_steering_mode via devlinkParams

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -171,6 +171,11 @@ const (
 	DevlinkParamApplyOnVf = "VF"
 	DevlinkParamApplyOnSf = "SF"
 
+	DevlinkParamFlowSteeringMode = "flow_steering_mode"
+
+	FlowSteeringModeSmfs = "smfs"
+	FlowSteeringModeHmfs = "hmfs"
+
 	OvsGroupingPolicyPerPF = "perPF"
 	OvsGroupingPolicyPerVF = "perVF"
 	OvsGroupingPolicyAll   = "all"

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -502,6 +502,11 @@ func (s *sriov) applyDevlinkParams(interfaces []interfaceToConfigure) error {
 			continue
 		}
 		for _, param := range iface.DevlinkParams.Params {
+			// flow_steering_mode is applied earlier in configureHWOptionsForSwitchdev,
+			// where the device can be temporarily flipped to legacy eswitch mode if required.
+			if param.Name == consts.DevlinkParamFlowSteeringMode {
+				continue
+			}
 			var err error
 			switch param.ApplyOn {
 			case consts.DevlinkParamApplyOnPf:
@@ -534,8 +539,19 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 	if err := s.networkHelper.EnableHwTcOffload(iface.Name); err != nil {
 		return err
 	}
-	desiredFlowSteeringMode := "smfs"
-	currentFlowSteeringMode, err := s.networkHelper.GetDevlinkDeviceParam(iface.PciAddress, "flow_steering_mode")
+	// Default to smfs unless the user explicitly requests a different mode via devlink params.
+	// flow_steering_mode is special: it must be applied while the device is in legacy eswitch mode,
+	// so we handle it here (not in applyDevlinkParams). applyDevlinkParams skips it accordingly.
+	desiredFlowSteeringMode := consts.FlowSteeringModeSmfs
+	for _, p := range iface.DevlinkParams.Params {
+		if p.ApplyOn == consts.DevlinkParamApplyOnPf &&
+			p.Name == consts.DevlinkParamFlowSteeringMode &&
+			p.Value != "" {
+			desiredFlowSteeringMode = p.Value
+			break
+		}
+	}
+	currentFlowSteeringMode, err := s.networkHelper.GetDevlinkDeviceParam(iface.PciAddress, consts.DevlinkParamFlowSteeringMode)
 	if err != nil {
 		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENODEV) {
 			log.Log.V(2).Info("configureHWOptionsForSwitchdev(): device has no flow_steering_mode parameter, skip",
@@ -561,7 +577,7 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 			return err
 		}
 	}
-	if err := s.networkHelper.SetDevlinkDeviceParam(iface.PciAddress, "flow_steering_mode", desiredFlowSteeringMode); err != nil {
+	if err := s.networkHelper.SetDevlinkDeviceParam(iface.PciAddress, consts.DevlinkParamFlowSteeringMode, desiredFlowSteeringMode); err != nil {
 		if errors.Is(err, syscall.ENOTSUP) {
 			log.Log.V(2).Info("configureHWOptionsForSwitchdev(): device doesn't support changing of flow_steering_mode, skip", "device", iface.PciAddress)
 			return nil

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -796,6 +796,90 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
+		It("should apply user-supplied flow_steering_mode=hmfs from devlinkParams and skip it in applyDevlinkParams", func() {
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
+				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+				Symlinks: map[string]string{"/sys/bus/pci/devices/0000:d8:00.2/physfn": "../../0000:d8:00.0"},
+			})
+
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil).Times(2)
+			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
+			// Device is in switchdev with smfs; user requested hmfs via devlinkParams,
+			// so the operator must flip back to legacy, set hmfs, then return to switchdev.
+			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("smfs", nil)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
+			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(6)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil).Times(2)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
+			// flow_steering_mode is applied here, NOT later in applyDevlinkParams.
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode", "hmfs").Return(nil)
+
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(3)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
+			hostMock.EXPECT().DeleteVDPADevice("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
+			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.2").Return(42, nil).AnyTimes()
+			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
+			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f0_0", HardwareAddr: vf0Mac})
+			netlinkLibMock.EXPECT().LinkByIndex(42).Return(vf0LinkMock, nil).AnyTimes()
+			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
+			hostMock.EXPECT().GetPhysPortName("enp216s0f0np0").Return("p0", nil)
+			hostMock.EXPECT().GetPhysSwitchID("enp216s0f0np0").Return("7cfe90ff2cc0", nil)
+			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
+			hostMock.EXPECT().LoadUdevRules().Return(nil)
+
+			// esw_multiport is applied normally by applyDevlinkParams; flow_steering_mode is NOT
+			// re-applied here (note the absence of a second SetDevlinkDeviceParam expectation for it).
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "esw_multiport", "true").Return(nil)
+
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+
+			Expect(s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:        "enp216s0f0np0",
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					LinkType:    "ETH",
+					EswitchMode: "switchdev",
+					DevlinkParams: sriovnetworkv1.DevlinkParams{
+						Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "flow_steering_mode", Value: "hmfs", ApplyOn: "PF"},
+							{Name: "esw_multiport", Value: "true", ApplyOn: "PF"},
+						},
+					},
+					VfGroups: []sriovnetworkv1.VfGroup{
+						{
+							VfRange:      "0-0",
+							ResourceName: "test-resource0",
+							PolicyName:   "test-policy0",
+							Mtu:          2000,
+							IsRdma:       true,
+						}},
+				}},
+				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
+				false)).NotTo(HaveOccurred())
+			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
+		})
+
 		It("should configure switchdev on ice driver", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0"},


### PR DESCRIPTION
configureHWOptionsForSwitchdev hardcoded the desired flow_steering_mode
to smfs, so users had no way to opt into hmfs (required, for example,
when running multiport e-switch).

Treat flow_steering_mode as a first-class but specially-handled devlink
param: when present in SriovNetworkNodePolicy.spec.devlinkParams.params
(applyOn: PF), use the user-supplied value as the desired mode in
configureHWOptionsForSwitchdev. The default remains smfs.

Skip flow_steering_mode in the generic applyDevlinkParams loop, since
that loop runs after VF setup and can't safely flip the device back to
legacy mode the way configureHWOptionsForSwitchdev does.