### PR TITLE
fix: drop explicit MFT installation from daemon image

### DIFF
--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -22,7 +22,7 @@ WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
-FROM nvcr.io/nvidia/doca/doca:3.3.0-base-rt-host
+FROM nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
 # We have to ensure that pciutils is installed. These packages are needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
 # DOCA repositories have a GPG issue, so we need to allow insecure repositories.
@@ -30,18 +30,6 @@ FROM nvcr.io/nvidia/doca/doca:3.3.0-base-rt-host
 RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
     apt-get install -y --allow-unauthenticated hwdata pciutils curl mstflint && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ARG TARGETARCH
-ENV MFT_VERSION=4.33.0-169
-RUN case ${TARGETARCH} in \
-        amd64) ARCH=x86_64 ;; \
-        arm64) ARCH=arm64 ;; \
-        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-${ARCH}-deb.tgz | tar -xz --no-same-owner -C /tmp && \
-    cd /tmp/mft-${MFT_VERSION}-${ARCH}-deb && \
-    ./install.sh --without-kernel
-
 
 # Delete the original mstconfig and mstfwreset binaries
 # We only need their dependent packages, not the binaries themselves.


### PR DESCRIPTION
DOCA full RT host image already contains the latest version of mft