### PR TITLE
refactor: split applyDevlinkParams into applyDevlinkPfParams and appl…

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -140,7 +140,7 @@ func (s *sriov) ResetSriovDevice(ifaceStatus sriovnetworkv1.InterfaceExt) error 
 			return err
 		}
 		log.Log.V(2).Info("ResetSriovDevice(): reset eswitch mode and number of VFs", "mode", eswitchMode)
-		if err := s.setEswitchModeAndNumVFs(ifaceStatus.PciAddress, ifaceStatus.Name, eswitchMode, 0); err != nil {
+		if err := s.setEswitchModeAndNumVFs(ifaceStatus.PciAddress, ifaceStatus.Name, eswitchMode, 0, ifaceStatus.DevlinkParams.Params); err != nil {
 			return err
 		}
 	} else if ifaceStatus.LinkType == consts.LinkTypeIB {
@@ -470,21 +470,21 @@ func (s *sriov) configSriovPFDevice(iface *sriovnetworkv1.Interface) error {
 	return nil
 }
 
-func (s *sriov) applyDevlinkPfParam(iface *sriovnetworkv1.Interface, param sriovnetworkv1.DevlinkParam) error {
-	return s.networkHelper.SetDevlinkDeviceParam(iface.PciAddress, param.Name, param.Value)
+func (s *sriov) applyDevlinkPfParam(pciAddress string, param sriovnetworkv1.DevlinkParam) error {
+	return s.networkHelper.SetDevlinkDeviceParam(pciAddress, param.Name, param.Value)
 }
 
-func (s *sriov) applyDevlinkVfParam(iface *sriovnetworkv1.Interface, param sriovnetworkv1.DevlinkParam) error {
-	vfAddrs, err := s.dputilsLib.GetVFList(iface.PciAddress)
+func (s *sriov) applyDevlinkVfParam(pciAddress string, param sriovnetworkv1.DevlinkParam) error {
+	vfAddrs, err := s.dputilsLib.GetVFList(pciAddress)
 	if err != nil {
-		log.Log.Error(err, "applyDevlinkVfParam(): fail to get VF list", "device", iface.PciAddress, "param")
+		log.Log.Error(err, "applyDevlinkVfParam(): fail to get VF list", "device", pciAddress, "param")
 		return err
 	}
 
 	for _, addr := range vfAddrs {
 		err = s.networkHelper.SetDevlinkDeviceParam(addr, param.Name, param.Value)
 		if err != nil {
-			log.Log.Error(err, "applyDevlinkVfParam(): fail apply devlink param for VF", "device", iface.PciAddress, "param")
+			log.Log.Error(err, "applyDevlinkVfParam(): fail apply devlink param for VF", "device", pciAddress, "param")
 			return err
 		}
 	}
@@ -492,40 +492,36 @@ func (s *sriov) applyDevlinkVfParam(iface *sriovnetworkv1.Interface, param sriov
 	return nil
 }
 
-// applyDevlinkParams applies devlink parameters for all configured interfaces.
-// This should be called after all interface configuration is complete (including switchdev mode and VF creation).
-func (s *sriov) applyDevlinkParams(interfaces []interfaceToConfigure) error {
-	log.Log.V(2).Info("applyDevlinkParams(): applying devlink params for configured interfaces")
-	for _, ifaceCfg := range interfaces {
-		iface := &ifaceCfg.Iface
-		if iface.ExternallyManaged {
+func (s *sriov) applyDevlinkPfParams(pciAddr string, devlinkParams []sriovnetworkv1.DevlinkParam) error {
+	for _, param := range devlinkParams {
+		// flow_steering_mode is applied earlier in configureHWOptionsForSwitchdev,
+		// where the device can be temporarily flipped to legacy eswitch mode if required.
+		if param.ApplyOn != consts.DevlinkParamApplyOnPf || param.Name == consts.DevlinkParamFlowSteeringMode {
 			continue
 		}
-		for _, param := range iface.DevlinkParams.Params {
-			// flow_steering_mode is applied earlier in configureHWOptionsForSwitchdev,
-			// where the device can be temporarily flipped to legacy eswitch mode if required.
-			if param.Name == consts.DevlinkParamFlowSteeringMode {
-				continue
-			}
-			var err error
-			switch param.ApplyOn {
-			case consts.DevlinkParamApplyOnPf:
-				err = s.applyDevlinkPfParam(iface, param)
-				if err != nil {
-					log.Log.Error(err, "applyDevlinkParams(): failed to apply devlink param for PF",
-						"device", iface.PciAddress, "param", param.Name)
-					return err
-				}
-			case consts.DevlinkParamApplyOnVf:
-				err = s.applyDevlinkVfParam(iface, param)
-				if err != nil {
-					log.Log.Error(err, "applyDevlinkParams(): failed to apply devlink param for VFs",
-						"device", iface.PciAddress, "param", param.Name)
-					return err
-				}
-			}
+
+		if err := s.applyDevlinkPfParam(pciAddr, param); err != nil {
+			log.Log.Error(err, "applyDevlinkPfParams(): failed to apply devlink param for PF",
+				"device", pciAddr, "param", param.Name)
+			return err
 		}
 	}
+
+	return nil
+}
+
+func (s *sriov) applyDevlinkVfParams(pciAddr string, devlinkParams []sriovnetworkv1.DevlinkParam) error {
+	for _, param := range devlinkParams {
+		if param.ApplyOn != consts.DevlinkParamApplyOnVf {
+			continue
+		}
+		if err := s.applyDevlinkVfParam(pciAddr, param); err != nil {
+			log.Log.Error(err, "applyDevlinkVfParams(): failed to apply devlink param for VFs",
+				"device", pciAddr, "param", param.Name)
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -571,7 +567,7 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 	}
 	// flow steering mode can be changed only when NIC is in legacy mode
 	if s.GetNicSriovMode(iface.PciAddress) != sriovnetworkv1.ESwithModeLegacy {
-		err = s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, sriovnetworkv1.ESwithModeLegacy, 0)
+		err = s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, sriovnetworkv1.ESwithModeLegacy, 0, iface.DevlinkParams.Params)
 		if err != nil {
 			log.Log.Error(err, "falied to switch Eswitch mode to legacy and reset number of vfs to 0")
 			return err
@@ -769,9 +765,10 @@ func (s *sriov) configSriovDevice(iface *sriovnetworkv1.Interface, skipVFConfigu
 			return err
 		}
 	}
-	if err := s.configSriovVFDevices(iface); err != nil {
-		return err
-	}
+	//if err := s.configSriovVFDevices(iface); err != nil {
+	//	return err
+	//}
+
 	// Set PF link up
 	pfLink, err := s.netlinkLib.LinkByName(iface.Name)
 	if err != nil {
@@ -828,13 +825,6 @@ func (s *sriov) ConfigSriovInterfaces(storeManager store.ManagerInterface,
 			log.Log.Error(err, "cannot reload udev rules")
 			return fmt.Errorf("failed to reload udev rules: %v", err)
 		}
-	}
-
-	// Apply devlink params after all interface configuration is complete.
-	// Some devlink params (e.g. esw_multiport) require switchdev mode and VFs to be ready.
-	if err := s.applyDevlinkParams(toBeConfigured); err != nil {
-		log.Log.Error(err, "cannot apply devlink params")
-		return fmt.Errorf("cannot apply devlink params: %v", err)
 	}
 
 	if vars.ParallelNicConfig {
@@ -953,6 +943,10 @@ func (s *sriov) resetSriovInterfacesInParallel(storeManager store.ManagerInterfa
 func (s *sriov) configSriovInterfaces(storeManager store.ManagerInterface, interfaces []interfaceToConfigure, skipVFConfiguration bool) error {
 	log.Log.V(2).Info("configSriovInterfaces(): start sriov configuration")
 	for _, iface := range interfaces {
+		expectedEswitchMode := sriovnetworkv1.GetEswitchModeFromSpec(&iface.Iface)
+		log.Log.V(2).Info("configSriovInterfaces(): configure VFs for device",
+			"device", iface.Iface.PciAddress, "count", iface.Iface.NumVfs, "mode", expectedEswitchMode)
+
 		if err := s.configSriovDevice(&iface.Iface, skipVFConfiguration); err != nil {
 			log.Log.Error(err, "configSriovInterfaces(): fail to configure sriov interface. resetting interface.", "address", iface.Iface.PciAddress)
 			if iface.Iface.ExternallyManaged {
@@ -965,13 +959,42 @@ func (s *sriov) configSriovInterfaces(storeManager store.ManagerInterface, inter
 			return err
 		}
 
+		//// Save the PF status to the host
+		//err := storeManager.SaveLastPfAppliedStatus(&iface.Iface)
+		//if err != nil {
+		//	log.Log.Error(err, "configSriovInterfaces(): failed to save PF applied config to host")
+		//	return err
+		//}
+	}
+
+	for _, iface := range interfaces {
+		pciAddr := iface.Iface.PciAddress
+		if err := s.applyDevlinkPfParams(pciAddr, iface.Iface.DevlinkParams.Params); err != nil {
+			return err
+		}
+		if err := s.SetSriovNumVfs(pciAddr, iface.Iface.NumVfs); err != nil {
+			return err
+		}
+		if err := s.waitForVFLinks(pciAddr, iface.Iface.NumVfs, 120*time.Second); err != nil {
+			return err
+		}
+		if err := s.configSriovVFDevices(&iface.Iface); err != nil {
+			return err
+		}
+		err := s.applyDevlinkVfParams(pciAddr, iface.Iface.DevlinkParams.Params)
+		if err != nil {
+			log.Log.Error(err, "cannot apply VF devlink params")
+			return fmt.Errorf("cannot apply VF devlink params")
+		}
+
 		// Save the PF status to the host
-		err := storeManager.SaveLastPfAppliedStatus(&iface.Iface)
+		err = storeManager.SaveLastPfAppliedStatus(&iface.Iface)
 		if err != nil {
 			log.Log.Error(err, "configSriovInterfaces(): failed to save PF applied config to host")
 			return err
 		}
 	}
+
 	log.Log.V(2).Info("configSriovInterfaces(): sriov configuration finished")
 	return nil
 }
@@ -1266,12 +1289,12 @@ func (s *sriov) createVFs(iface *sriovnetworkv1.Interface) error {
 			return nil
 		}
 	}
-	return s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, expectedEswitchMode, iface.NumVfs)
+	return s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, expectedEswitchMode, iface.NumVfs, iface.DevlinkParams.Params)
 }
 
-type setEswitchModeAndNumVFsFn func(string, string, string, int) error
+type setEswitchModeAndNumVFsFn func(string, string, string, int, []sriovnetworkv1.DevlinkParam) error
 
-func (s *sriov) setEswitchModeAndNumVFs(pciAddr string, pfName string, desiredEswitchMode string, numVFs int) error {
+func (s *sriov) setEswitchModeAndNumVFs(pciAddr string, pfName string, desiredEswitchMode string, numVFs int, devlinkParams []sriovnetworkv1.DevlinkParam) error {
 	pfDriverName, err := s.dputilsLib.GetDriverName(pciAddr)
 	if err != nil {
 		return err
@@ -1281,8 +1304,8 @@ func (s *sriov) setEswitchModeAndNumVFs(pciAddr string, pfName string, desiredEs
 		"device", pciAddr, "count", numVFs, "mode", desiredEswitchMode, "driver", pfDriverName)
 
 	setEswitchModeAndNumVFsByDriverName := map[string]setEswitchModeAndNumVFsFn{
-		"ice":       s.setEswitchModeAndNumVFsIce,
-		"mlx5_core": s.setEswitchModeAndNumVFsMlx,
+		"ice":       s.setEswitchModeVFsIce,
+		"mlx5_core": s.setEswitchModeMlx,
 	}
 
 	fn, ok := setEswitchModeAndNumVFsByDriverName[pfDriverName]
@@ -1291,10 +1314,10 @@ func (s *sriov) setEswitchModeAndNumVFs(pciAddr string, pfName string, desiredEs
 			"device", pciAddr, "driver", pfDriverName)
 
 		// Fallback to mlx5 driver
-		fn = s.setEswitchModeAndNumVFsMlx
+		fn = s.setEswitchModeMlx
 	}
 
-	return fn(pciAddr, pfName, desiredEswitchMode, numVFs)
+	return fn(pciAddr, pfName, desiredEswitchMode, numVFs, devlinkParams)
 }
 
 func (s *sriov) waitForVFLinks(pciAddr string, expectedNum int, maxTimeout time.Duration) error {
@@ -1362,56 +1385,31 @@ func (s *sriov) waitForVFLinks(pciAddr string, expectedNum int, maxTimeout time.
 	return nil
 }
 
-// setEswitchModeAndNumVFsMlx configures PF eSwitch and sriov_numvfs in the following order:
-// a. set eSwitchMode to legacy
-// b. set the desired number of Virtual Functions
-// c. unbind driver of all VFs
-// d. set eSwitchMode to `switchdev` if requested
-func (s *sriov) setEswitchModeAndNumVFsMlx(pciAddr string, pfName string, desiredEswitchMode string, numVFs int) error {
-	log.Log.V(2).Info("setEswitchModeAndNumVFsMlx(): configure VFs for device",
+// setEswitchModeMlx configures PF eSwitch mode.
+// If the desired mode is switchdev, it unbinds all VFs and then sets the eswitch mode to switchdev.
+func (s *sriov) setEswitchModeMlx(pciAddr string, pfName string, desiredEswitchMode string, numVFs int, devlinkParams []sriovnetworkv1.DevlinkParam) error {
+	log.Log.V(2).Info("setEswitchModeMlx(): configure VFs for device",
 		"device", pciAddr, "count", numVFs, "mode", desiredEswitchMode)
-
-	// always switch NIC to the legacy mode before creating VFs. This is required because some drivers
-	// may not support VF creation in the switchdev mode
-	if s.GetNicSriovMode(pciAddr) != sriovnetworkv1.ESwithModeLegacy {
-		// detach PF from the managed bridge before switching the mode,
-		// changing of eSwitch mode may fail if NIC is part of the bridge (has offloaded TC rules)
-		if err := s.detachPFFromBridge(pciAddr, pfName, numVFs); err != nil {
-			return err
-		}
-		if err := s.unbindAllVFsOnPF(pciAddr); err != nil {
-			log.Log.Error(err, "setEswitchModeAndNumVFsMlx(): failed to unbind VFs", "device", pciAddr, "mode", desiredEswitchMode)
-			return err
-		}
-		if err := s.SetNicSriovMode(pciAddr, sriovnetworkv1.ESwithModeLegacy); err != nil {
-			return err
-		}
-	}
-	if err := s.SetSriovNumVfs(pciAddr, numVFs); err != nil {
-		return err
-	}
-	if err := s.waitForVFLinks(pciAddr, numVFs, 120*time.Second); err != nil {
-		return err
-	}
 
 	if desiredEswitchMode == sriovnetworkv1.ESwithModeSwitchDev {
 		if err := s.unbindAllVFsOnPF(pciAddr); err != nil {
-			log.Log.Error(err, "setEswitchModeAndNumVFsMlx(): failed to unbind VFs", "device", pciAddr, "mode", desiredEswitchMode)
+			log.Log.Error(err, "setEswitchModeMlx(): failed to unbind VFs", "device", pciAddr, "mode", desiredEswitchMode)
 			return err
 		}
 		if err := s.SetNicSriovMode(pciAddr, desiredEswitchMode); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-// setEswitchModeAndNumVFsIce configures PF eSwitch and sriov_numvfs in the following order:
+// setEswitchModeVFsIce configures PF eSwitch and sriov_numvfs in the following order:
 // a. set eSwitchMode to the desired mode if needed
 // a1. set sriov_numvfs to 0 before updating the eSwitchMode
 // b. set sriov_numvfs to the desired number of VFs
-func (s *sriov) setEswitchModeAndNumVFsIce(pciAddr string, pfName string, desiredEswitchMode string, numVFs int) error {
-	log.Log.V(2).Info("setEswitchModeAndNumVFsIce(): configure VFs for device",
+func (s *sriov) setEswitchModeVFsIce(pciAddr string, pfName string, desiredEswitchMode string, numVFs int, devlinkParams []sriovnetworkv1.DevlinkParam) error {
+	log.Log.V(2).Info("setEswitchModeVFsIce(): configure VFs for device",
 		"device", pciAddr, "count", numVFs, "mode", desiredEswitchMode)
 
 	if s.GetNicSriovMode(pciAddr) != desiredEswitchMode {

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -251,8 +251,6 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -342,72 +340,28 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
-			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(3)
-			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(1)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
-
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
-			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
-			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
-			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
-			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
-			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
-			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.2").Return(42, nil)
-			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
-			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
-			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f0_0", HardwareAddr: vf0Mac}).AnyTimes()
-			netlinkLibMock.EXPECT().LinkByIndex(42).Return(vf0LinkMock, nil)
-			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
-
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.3").Return(1, nil)
-			hostMock.EXPECT().HasDriver("0000:d8:00.3").Return(true, "vfio-pci").Times(2)
-			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.3", false).Return(nil)
-			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.1").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.1").Return(0)
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.1").Return("mlx5_core", nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.1").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.1").Return(nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.1").Return([]string{"0000:d8:00.4", "0000:d8:00.5"}, nil).AnyTimes()
 			pf1LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
-			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np1").Return(pf1LinkMock, nil).Times(3)
-			pf1LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np1").Return(pf1LinkMock, nil).Times(1)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pf1LinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pf1LinkMock).Return(nil)
-
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.4").Return(0, nil).Times(2)
-			hostMock.EXPECT().HasDriver("0000:d8:00.4").Return(false, "")
-			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.4").Return(nil)
-			hostMock.EXPECT().HasDriver("0000:d8:00.4").Return(true, "test")
-			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.4", true).Return(nil)
-			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.4").Return(nil)
-			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.4", 2000).Return(nil)
-			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.4").Return(43, nil)
-			pf1vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
-			pf1vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:bf")
-			pf1vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f1_0", HardwareAddr: pf1vf0Mac}).AnyTimes()
-			netlinkLibMock.EXPECT().LinkByIndex(43).Return(pf1vf0LinkMock, nil)
-			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, pf1vf0Mac).Return(nil)
-
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.5").Return(1, nil)
-			hostMock.EXPECT().HasDriver("0000:d8:00.5").Return(true, "vfio-pci").Times(2)
-			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.5", false).Return(nil)
-			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.5", "vfio-pci").Return(nil)
 
 			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil).Times(2)
 
@@ -457,8 +411,6 @@ var _ = Describe("SRIOV", func() {
 					}},
 				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}, {PciAddress: "0000:d8:00.1"}},
 				false)).NotTo(HaveOccurred())
-			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "2")
-			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.1/sriov_numvfs", "2")
 		})
 
 		It("should configure IB", func() {
@@ -471,8 +423,6 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -537,7 +487,7 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
@@ -607,7 +557,7 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
@@ -677,7 +627,7 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
@@ -724,7 +674,7 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
-		It("should configure configure swtichdev by switching back to legacy mode and configure smfs", func() {
+		It("should configure switchdev and set smfs flow steering mode", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
@@ -747,13 +697,12 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(6)
-			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(2)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
 			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode", "smfs").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(3)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(1)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -796,7 +745,7 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
-		It("should apply user-supplied flow_steering_mode=hmfs from devlinkParams and skip it in applyDevlinkParams", func() {
+		It("should apply user-supplied flow_steering_mode=hmfs from devlinkParams and skip it in applyDevlinkPfParams", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
@@ -812,8 +761,6 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
-			// Device is in switchdev with smfs; user requested hmfs via devlinkParams,
-			// so the operator must flip back to legacy, set hmfs, then return to switchdev.
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("smfs", nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
@@ -821,14 +768,13 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(6)
-			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(2)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
-			// flow_steering_mode is applied here, NOT later in applyDevlinkParams.
+			// flow_steering_mode is applied here, NOT later in applyDevlinkPfParams.
 			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode", "hmfs").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(3)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(1)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -847,7 +793,7 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
 			hostMock.EXPECT().LoadUdevRules().Return(nil)
 
-			// esw_multiport is applied normally by applyDevlinkParams; flow_steering_mode is NOT
+			// esw_multiport is applied normally by applyDevlinkPfParams; flow_steering_mode is NOT
 			// re-applied here (note the absence of a second SetDevlinkDeviceParam expectation for it).
 			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "esw_multiport", "true").Return(nil)
 
@@ -882,8 +828,11 @@ var _ = Describe("SRIOV", func() {
 
 		It("should configure switchdev on ice driver", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
-				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files: map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+				Symlinks: map[string]string{
+					"/sys/bus/pci/devices/0000:d8:00.2/physfn": "../../0000:d8:00.0",
+				},
 			})
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
@@ -896,7 +845,7 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("", syscall.EINVAL)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
@@ -1008,9 +957,6 @@ var _ = Describe("SRIOV", func() {
 				NumVfs:     2,
 			}, true, nil)
 			storeManagerMode.EXPECT().RemovePfAppliedStatus("0000:d8:00.0").Return(nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
-				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
-				nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -1027,7 +973,6 @@ var _ = Describe("SRIOV", func() {
 						NumVfs:     2,
 						TotalVfs:   2,
 					}}, false)).NotTo(HaveOccurred())
-			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "0")
 		})
 
 		It("should reset devices in parallel", func() {
@@ -1047,9 +992,6 @@ var _ = Describe("SRIOV", func() {
 				NumVfs:     2,
 			}, true, nil)
 			storeManagerMode.EXPECT().RemovePfAppliedStatus("0000:d8:00.0").Return(nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
-				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
-				nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -1062,9 +1004,6 @@ var _ = Describe("SRIOV", func() {
 				NumVfs:     2,
 			}, true, nil)
 			storeManagerMode.EXPECT().RemovePfAppliedStatus("0000:d8:00.1").Return(nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.1").Return(
-				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
-				nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
@@ -1088,7 +1027,6 @@ var _ = Describe("SRIOV", func() {
 						NumVfs:     2,
 						TotalVfs:   2,
 					}}, false)).NotTo(HaveOccurred())
-			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "0")
 		})
 
 		It("reset device - skip external", func() {
@@ -1122,9 +1060,6 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
-			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
-				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
-				nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -1132,6 +1067,29 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil).AnyTimes()
 			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().Unbind("0000:d8:00.3").Return(nil)
+
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
+			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
+
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
+			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.2").Return(42, nil)
+			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
+			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f0_0", HardwareAddr: vf0Mac}).AnyTimes()
+			netlinkLibMock.EXPECT().LinkByIndex(42).Return(vf0LinkMock, nil)
+			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
+
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.3").Return(1, nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.3").Return(true, "vfio-pci").Times(2)
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.3", false).Return(nil)
+			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
 
 			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
 
@@ -1187,7 +1145,7 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)


### PR DESCRIPTION
…yDevlinkVfParams

Call applyDevlinkPfParams after configSriovPFDevice and applyDevlinkVfParams after configSriovVFDevices instead of applying all params in a single pass after all interfaces are configured.