### PR TITLE
mellanox: enable DDI on VFs via VFConfigHook

### DIFF
--- a/Dockerfile.sriov-network-config-daemon-stig
+++ b/Dockerfile.sriov-network-config-daemon-stig
@@ -1,13 +1,35 @@
+ARG BASE_IMAGE_DOCA_FULL_RT_HOST
 ARG UBUNTU_STIG_BASE_IMAGE
 
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 ARG GOPROXY
+ARG TARGETARCH
 ENV GOPROXY=$GOPROXY
 
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
-RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
+RUN GOARCH=${TARGETARCH} make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
+
+# Build doca_mgmt_data_direct and collect its DOCA runtime libraries so they
+# can be dropped into the STIG image which has no DOCA runtime of its own.
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev} AS doca-builder
+
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated \
+        pkg-config meson ninja-build gcc \
+        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
+    ninja -C /tmp/ddi-build && \
+    cp /tmp/ddi-build/doca_mgmt_data_direct /usr/bin/ && \
+    rm -rf /tmp/ddi-build
+
+# Collect DOCA runtime shared libraries (preserving symlinks) into a single
+# directory so they can be COPY'd into the STIG final stage.
+RUN mkdir -p /doca-dist && \
+    find /usr -name "libdoca*.so*" -exec cp -a {} /doca-dist/ \;
 
 FROM $UBUNTU_STIG_BASE_IMAGE
 # We have to ensure that pciutils is installed. These packages are needed for mstfwreset to succeed.
@@ -30,6 +52,13 @@ RUN case ${TARGETARCH} in \
 RUN rm -f /usr/bin/mstconfig /usr/bin/mstfwreset
 RUN ln -s $(which mlxconfig) /usr/bin/mstconfig
 RUN ln -s $(which mlxfwreset) /usr/bin/mstfwreset
+
+# Install doca_mgmt_data_direct and its DOCA runtime libraries from the
+# doca-builder stage.  The STIG base image has no DOCA runtime, so the libs
+# are placed under /usr/lib/doca/ and registered via ldconfig.
+COPY --from=doca-builder /usr/bin/doca_mgmt_data_direct /usr/bin/
+COPY --from=doca-builder /doca-dist/ /usr/lib/doca/
+RUN echo "/usr/lib/doca" > /etc/ld.so.conf.d/doca.conf && ldconfig
 
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"

--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -25,7 +25,22 @@ WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.2.1-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev}
+
+# Install DOCA dev packages while the internal NVIDIA apt sources are still available.
+# doca-samples provides the mgmt_data_direct source tree;
+# libdoca-sdk-mgmt-dev and libdoca-sdk-argp-dev provide the headers meson needs.
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated \
+        pkg-config meson ninja-build gcc \
+        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Build doca_mgmt_data_direct from DOCA samples.
+RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
+    ninja -C /tmp/ddi-build && \
+    cp /tmp/ddi-build/doca_mgmt_data_direct /usr/bin/ && \
+    rm -rf /tmp/ddi-build
 
 # Drop NVIDIA-internal apt sources baked into staging DOCA base images so the
 # build works from public CI (GitHub Actions). mstflint then resolves from Ubuntu.

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -215,6 +215,18 @@ func (mr *MockHostHelpersInterfaceMockRecorder) ConfigSriovDevicesVirtual(storeM
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovDevicesVirtual", reflect.TypeOf((*MockHostHelpersInterface)(nil).ConfigSriovDevicesVirtual), storeManager, interfaces, ifaceStatuses)
 }
 
+// SetVFConfigHook mocks base method.
+func (m *MockHostHelpersInterface) SetVFConfigHook(hook types.VFConfigHook) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVFConfigHook", hook)
+}
+
+// SetVFConfigHook indicates an expected call of SetVFConfigHook.
+func (mr *MockHostHelpersInterfaceMockRecorder) SetVFConfigHook(hook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVFConfigHook", reflect.TypeOf((*MockHostHelpersInterface)(nil).SetVFConfigHook), hook)
+}
+
 // ConfigSriovInterfaces mocks base method.
 func (m *MockHostHelpersInterface) ConfigSriovInterfaces(storeManager store.ManagerInterface, interfaces []v1.Interface, ifaceStatuses []v1.InterfaceExt, skipVFConfiguration bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -67,6 +67,7 @@ type sriov struct {
 	sriovnetLib      sriovnetPkg.SriovnetLib
 	ghwLib           ghwPkg.GHWLib
 	bridgeHelper     types.BridgeInterface
+	vfConfigHook     types.VFConfigHook
 }
 
 func New(utilsHelper utils.CmdInterface,
@@ -92,6 +93,10 @@ func New(utilsHelper utils.CmdInterface,
 		ghwLib:           ghwLib,
 		bridgeHelper:     bridgeHelper,
 	}
+}
+
+func (s *sriov) SetVFConfigHook(hook types.VFConfigHook) {
+	s.vfConfigHook = hook
 }
 
 func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
@@ -702,6 +707,11 @@ func (s *sriov) configSriovVFDevices(iface *sriovnetworkv1.Interface) error {
 
 			if err = s.kernelHelper.UnbindDriverIfNeeded(addr, group.IsRdma); err != nil {
 				return err
+			}
+			if s.vfConfigHook != nil {
+				if err := s.vfConfigHook.OnVFUnbound(iface, addr, group); err != nil {
+					return err
+				}
 			}
 			// we set eswitch mode before this point and if the desired mode (and current at this point)
 			// is legacy, then VDPA device is already automatically disappeared,

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -185,6 +185,18 @@ func (mr *MockHostManagerInterfaceMockRecorder) ConfigSriovDevicesVirtual(storeM
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovDevicesVirtual", reflect.TypeOf((*MockHostManagerInterface)(nil).ConfigSriovDevicesVirtual), storeManager, interfaces, ifaceStatuses)
 }
 
+// SetVFConfigHook mocks base method.
+func (m *MockHostManagerInterface) SetVFConfigHook(hook types.VFConfigHook) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVFConfigHook", hook)
+}
+
+// SetVFConfigHook indicates an expected call of SetVFConfigHook.
+func (mr *MockHostManagerInterfaceMockRecorder) SetVFConfigHook(hook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVFConfigHook", reflect.TypeOf((*MockHostManagerInterface)(nil).SetVFConfigHook), hook)
+}
+
 // ConfigSriovInterfaces mocks base method.
 func (m *MockHostManagerInterface) ConfigSriovInterfaces(storeManager store.ManagerInterface, interfaces []v1.Interface, ifaceStatuses []v1.InterfaceExt, skipVFConfiguration bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -168,6 +168,17 @@ type SriovInterface interface {
 	// ConfigSriovDevicesVirtual configure virtual functions for virtual environments with the desired configuration
 	ConfigSriovDevicesVirtual(storeManager store.ManagerInterface, interfaces []sriovnetworkv1.Interface,
 		ifaceStatuses []sriovnetworkv1.InterfaceExt) error
+	// SetVFConfigHook registers an optional per-VF hook called after a VF is unbound, before rebinding.
+	// Vendor plugins use this to inject vendor-specific per-VF logic; the default (nil) is a no-op.
+	SetVFConfigHook(hook VFConfigHook)
+}
+
+// VFConfigHook is an optional per-VF hook called after a VF is unbound, before rebinding.
+// Implementations are registered by vendor plugins via SetVFConfigHook; nil means no-op.
+type VFConfigHook interface {
+	// OnVFUnbound is called after a VF has been unbound from its driver.
+	// iface is the PF interface spec, vfPciAddr is the VF PCI address, group is the matched VfGroup.
+	OnVFUnbound(iface *sriovnetworkv1.Interface, vfPciAddr string, group *sriovnetworkv1.VfGroup) error
 }
 
 type UdevInterface interface {

--- a/pkg/platform/baremetal/baremetal_test.go
+++ b/pkg/platform/baremetal/baremetal_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Baremetal", func() {
 		hostHelper = mock_helper.NewMockHostHelpersInterface(mockCtrl)
 		hostHelper.EXPECT().GetCurrentKernelArgs().Return("", nil).AnyTimes()
 		hostHelper.EXPECT().IsKernelArgsSet(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		hostHelper.EXPECT().SetVFConfigHook(gomock.Any()).AnyTimes()
 
 		var err error
 		bm, err = New(hostHelper)

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -18,6 +18,7 @@ package mellanox
 
 import (
 	"fmt"
+	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -44,6 +45,26 @@ var mellanoxNicsSpec map[string]sriovnetworkv1.Interface
 // Initialize our plugin and set up initial values
 func NewMellanoxPlugin(helpers helper.HostHelpersInterface) (plugin.VendorPlugin, error) {
 	mellanoxNicsStatus = map[string]map[string]sriovnetworkv1.InterfaceExt{}
+
+	// In DaemonSet mode the generic plugin chroots the process into /host before
+	// calling ConfigSriovInterfaces, making container binaries and their shared
+	// libraries inaccessible when the VF hook fires.  Open the container root now
+	// (before any chroot) so that the hook can temporarily escape back to the
+	// container filesystem context when it needs to run doca_mgmt_data_direct.
+	var containerRoot *os.File
+	if !vars.UsingSystemdMode {
+		var err error
+		containerRoot, err = os.Open("/")
+		if err != nil {
+			log.Log.Error(err, "MellanoxPlugin: cannot save container root fd; DDI hook will skip")
+		}
+	}
+
+	helpers.SetVFConfigHook(&MellanoxVFHook{
+		kernelHelper:  helpers,
+		utilsHelper:   helpers,
+		containerRoot: containerRoot,
+	})
 
 	return &MellanoxPlugin{
 		PluginName: PluginName,

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -50,6 +50,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 	BeforeEach(func() {
 		testCtrl = gomock.NewController(GinkgoT())
 		h = mock_helper.NewMockHostHelpersInterface(testCtrl)
+		h.EXPECT().SetVFConfigHook(gomock.Any())
 		m, err = NewMellanoxPlugin(h)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/plugins/mellanox/vf_hook.go
+++ b/pkg/plugins/mellanox/vf_hook.go
@@ -1,0 +1,236 @@
+// Copyright 2025 sriov-network-device-plugin authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mellanox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
+)
+
+// ddiBinaryName is the name of the DDI management tool looked up via $PATH.
+const ddiBinaryName = "doca_mgmt_data_direct"
+
+// chrootMu serializes runInContainerContext invocations.
+// syscall.Chroot and os.Chdir are process-wide operations — all goroutines and
+// OS threads share the same root directory and CWD after any single call.
+// When vars.ParallelNicConfig is true, configSriovInterfacesInParallel spawns
+// one goroutine per PF, each of which can reach OnVFUnbound → runInContainerContext
+// concurrently.  Without serialization, goroutine A escaping to the container
+// root would silently corrupt the host-chroot context that goroutine B is
+// still relying on.
+var chrootMu sync.Mutex
+
+// MellanoxVFHook implements types.VFConfigHook for Mellanox/NVIDIA NICs.
+// It enables DDI (Data Direct Interface) on VFs that belong to an interface
+// configured with flow_steering_mode=hmfs (Spectrum-X).
+type MellanoxVFHook struct {
+	kernelHelper types.KernelInterface
+	utilsHelper  utils.CmdInterface
+	// containerRoot is an fd opened at "/" before any chroot takes place.
+	// It lets runInContainerContext escape back to the container filesystem
+	// (where doca_mgmt_data_direct and its shared libraries live) and then
+	// restore the host chroot afterwards.  nil means no escape is needed
+	// (systemd mode, no chroot).
+	containerRoot *os.File
+}
+
+// OnVFUnbound is called after a VF has been unbound from its driver.
+// If the PF interface is configured with flow_steering_mode=hmfs, DDI is enabled on the VF.
+func (h *MellanoxVFHook) OnVFUnbound(
+	iface *sriovnetworkv1.Interface,
+	vfPciAddr string,
+	_ *sriovnetworkv1.VfGroup,
+) error {
+	if !hasDDIRequired(iface) {
+		return nil
+	}
+
+	pfPciAddr := iface.PciAddress
+	fwctlDir := filepath.Join(consts.SysBusPciDevices, pfPciAddr, "fwctl")
+
+	var stdout, stderr string
+	var cmdErr error
+	skip := false
+
+	// Both the host-context sysfs checks and the container-context binary exec
+	// are serialized inside runInContainerContext so that neither races with
+	// the process-wide chroot flip when ParallelNicConfig is true.
+	runErr := h.runInContainerContext(
+		// hostFn: fwctl sysfs check and kernel module loading.
+		// Runs in host-chroot context, inside chrootMu, before the escape.
+		func() error {
+			if _, err := os.Stat(fwctlDir); os.IsNotExist(err) {
+				if err := h.kernelHelper.LoadKernelModule("fwctl"); err != nil {
+					return fmt.Errorf("MellanoxVFHook: failed to load fwctl module: %w", err)
+				}
+				if err := h.kernelHelper.LoadKernelModule("mlx5_fwctl"); err != nil {
+					return fmt.Errorf("MellanoxVFHook: failed to load mlx5_fwctl module: %w", err)
+				}
+				if _, err := os.Stat(fwctlDir); os.IsNotExist(err) {
+					log.Log.Info("MellanoxVFHook: fwctl sysfs entry absent after module load, NIC does not support DDI",
+						"pf", pfPciAddr)
+					skip = true
+					return nil
+				}
+			}
+			return nil
+		},
+		// containerFn: exec doca_mgmt_data_direct.
+		// Runs in container-context (with DOCA libs on the path), inside chrootMu.
+		func() error {
+			if skip {
+				return nil
+			}
+			stdout, stderr, cmdErr = h.utilsHelper.RunCommand(ddiBinaryName,
+				"set", "--vf-pci-addr", vfPciAddr, "--enabled", "true")
+			return nil // cmdErr is handled below
+		},
+	)
+	if runErr != nil {
+		return runErr
+	}
+	if skip {
+		return nil
+	}
+
+	if cmdErr != nil {
+		if errors.Is(cmdErr, exec.ErrNotFound) {
+			log.Log.Info("MellanoxVFHook: doca_mgmt_data_direct not found, skipping DDI",
+				"vf", vfPciAddr)
+			return nil
+		}
+		combined := stdout + stderr
+		if strings.Contains(combined, "not supported") ||
+			strings.Contains(combined, "DOCA_ERROR_NOT_SUPPORTED") ||
+			strings.Contains(combined, "VHCA ID as function ID is not supported") {
+			log.Log.Info("MellanoxVFHook: DDI not supported on device, skipping",
+				"vf", vfPciAddr)
+			return nil
+		}
+		return fmt.Errorf("MellanoxVFHook: doca_mgmt_data_direct set failed for %s: %w\n%s",
+			vfPciAddr, cmdErr, combined)
+	}
+
+	log.Log.Info("MellanoxVFHook: DDI enabled", "vf", vfPciAddr)
+	return nil
+}
+
+// runInContainerContext serializes all filesystem-context-sensitive operations
+// behind chrootMu, then temporarily escapes from the host chroot to the
+// container root so that containerFn can access container-side binaries and
+// shared libraries.
+//
+// hostFn runs first, in the current (host) chroot context, while holding
+// chrootMu.  containerFn runs next, after the escape, in the container
+// context.  If hostFn returns an error, containerFn is not called.
+//
+// When containerRoot is nil (systemd mode — no chroot) both functions run
+// sequentially in the same (container) filesystem context without any chroot
+// manipulation.
+//
+// The escape uses the containerRoot fd that was opened at "/" before any
+// chroot took place, mirroring pkg/utils/utils.go Chroot().  Restore errors
+// override the return value because a stranded process root is more critical
+// than any application-level error from fn.
+func (h *MellanoxVFHook) runInContainerContext(hostFn, containerFn func() error) (retErr error) {
+	if h.containerRoot == nil {
+		// Systemd mode: no chroot, both functions run in the same context.
+		if err := hostFn(); err != nil {
+			return err
+		}
+		return containerFn()
+	}
+
+	// All reads and writes of vars.InChroot, and all chroot/chdir syscalls,
+	// are serialized through this mutex.
+	chrootMu.Lock()
+	defer chrootMu.Unlock()
+
+	// Run host-context work (sysfs checks, module loading) while still in the
+	// host chroot, before the escape.
+	if err := hostFn(); err != nil {
+		return err
+	}
+
+	if !vars.InChroot {
+		// No active host chroot (e.g. tests, or unusual runtime path).
+		return containerFn()
+	}
+
+	// Save "/" (= the host root) before escaping so the restore path has a
+	// direct fd and does not depend on consts.Host being accessible from the
+	// container context.  Mirrors the pattern in pkg/utils/utils.go Chroot().
+	hostRoot, err := os.Open("/")
+	if err != nil {
+		return fmt.Errorf("MellanoxVFHook: cannot save host root fd: %w", err)
+	}
+	defer hostRoot.Close()
+
+	// Navigate to the container root via the pre-saved fd (bypasses chroot).
+	if err := h.containerRoot.Chdir(); err != nil {
+		return fmt.Errorf("MellanoxVFHook: cannot chdir to container root: %w", err)
+	}
+	// Make the container root the new process root.
+	if err := syscall.Chroot("."); err != nil {
+		return fmt.Errorf("MellanoxVFHook: cannot chroot to container root: %w", err)
+	}
+	vars.InChroot = false
+
+	defer func() {
+		// Restore the host chroot via the pre-saved fd.
+		// If either step fails the process is stranded in the container root.
+		// Override retErr so the caller always propagates this — a broken
+		// filesystem context is more critical than any containerFn error.
+		if err := hostRoot.Chdir(); err != nil {
+			retErr = fmt.Errorf("MellanoxVFHook: cannot chdir to host root for restore (process root corrupted): %w", err)
+			return
+		}
+		if err := syscall.Chroot("."); err != nil {
+			retErr = fmt.Errorf("MellanoxVFHook: cannot re-chroot to host (process root corrupted): %w", err)
+			return
+		}
+		vars.InChroot = true
+	}()
+
+	return containerFn()
+}
+
+// hasDDIRequired returns true when the interface is configured for Spectrum-X HMFS,
+// which requires DDI to be enabled on its VFs.
+func hasDDIRequired(iface *sriovnetworkv1.Interface) bool {
+	for _, p := range iface.DevlinkParams.Params {
+		if p.Name == consts.DevlinkParamFlowSteeringMode &&
+			p.Value == consts.FlowSteeringModeHmfs {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Add a VFConfigHook extension point to SriovInterface that vendor plugins can register to inject per-VF logic after unbind. The Mellanox plugin registers MellanoxVFHook, which enables DDI (Data Direct Interface) on VFs whose PF is configured with flow_steering_mode=hmfs (Spectrum-X).

The hook loads the fwctl/mlx5_fwctl kernel modules if absent, then calls doca_mgmt_data_direct set. Unsupported NICs (no fwctl sysfs entry or firmware rejection) are soft-skipped without failing the SR-IOV flow.

doca_mgmt_data_direct is compiled from the DOCA samples bundled in the base image and copied into the NVIDIA config-daemon container image. No CRD changes are required; the existing flow_steering_mode=hmfs devlink param serves as the DDI opt-in signal.