### PR TITLE
refactor: apply devlink parameters by target

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -204,15 +204,24 @@ func GetEswitchModeFromStatus(ifaceStatus *InterfaceExt) string {
 	return ifaceStatus.EswitchMode
 }
 
+func normalizedDevlinkApplyOn(applyOn string) string {
+	if applyOn == "" {
+		return consts.DevlinkParamApplyOnPf
+	}
+	return strings.ToUpper(applyOn)
+}
+
 func NeedToUpdateDevlinkParams(desired *DevlinkParams, current *DevlinkParams) bool {
 	for _, dParam := range desired.Params {
 		found := false
 		for _, cParam := range current.Params {
-			if dParam.Name == cParam.Name {
+			if dParam.Name == cParam.Name &&
+				normalizedDevlinkApplyOn(dParam.ApplyOn) == normalizedDevlinkApplyOn(cParam.ApplyOn) {
 				found = true
 				if dParam.Value != cParam.Value {
 					log.V(0).Info("NeedToUpdateDevlinkParams(): DevlinkParam needs update",
-						"name", dParam.Name, "desired", dParam.Value, "current", cParam.Value)
+						"name", dParam.Name, "applyOn", normalizedDevlinkApplyOn(dParam.ApplyOn),
+						"desired", dParam.Value, "current", cParam.Value)
 					return true
 				}
 				break
@@ -225,6 +234,16 @@ func NeedToUpdateDevlinkParams(desired *DevlinkParams, current *DevlinkParams) b
 		}
 	}
 	return false
+}
+
+func devlinkParamsForTarget(params *DevlinkParams, target string) DevlinkParams {
+	filtered := DevlinkParams{Params: make([]DevlinkParam, 0)}
+	for _, param := range params.Params {
+		if normalizedDevlinkApplyOn(param.ApplyOn) == target {
+			filtered.Params = append(filtered.Params, param)
+		}
+	}
+	return filtered
 }
 
 func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
@@ -306,8 +325,20 @@ func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 		}
 	}
 
-	if NeedToUpdateDevlinkParams(&ifaceSpec.DevlinkParams, &ifaceStatus.DevlinkParams) {
+	desiredPFParams := devlinkParamsForTarget(&ifaceSpec.DevlinkParams, consts.DevlinkParamApplyOnPf)
+	if NeedToUpdateDevlinkParams(&desiredPFParams, &ifaceStatus.DevlinkParams) {
 		return true
+	}
+	desiredVFParams := devlinkParamsForTarget(&ifaceSpec.DevlinkParams, consts.DevlinkParamApplyOnVf)
+	if len(desiredVFParams.Params) > 0 {
+		if len(ifaceStatus.VFs) < ifaceSpec.NumVfs {
+			return true
+		}
+		for i := range ifaceStatus.VFs {
+			if NeedToUpdateDevlinkParams(&desiredVFParams, &ifaceStatus.VFs[i].DevlinkParams) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -1096,6 +1096,45 @@ func TestNeedToUpdateSriov(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "VF devlink parameter already configured",
+			args: args{
+				ifaceSpec: &v1.Interface{
+					NumVfs: 1,
+					DevlinkParams: v1.DevlinkParams{Params: []v1.DevlinkParam{
+						{Name: "test", Value: "1", ApplyOn: "VF"},
+					}},
+				},
+				ifaceStatus: &v1.InterfaceExt{
+					NumVfs: 1,
+					VFs: []v1.VirtualFunction{{
+						DevlinkParams: v1.DevlinkParams{Params: []v1.DevlinkParam{
+							{Name: "test", Value: "1", ApplyOn: "VF"},
+						}},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "VF devlink parameter missing",
+			args: args{
+				ifaceSpec: &v1.Interface{
+					NumVfs: 1,
+					DevlinkParams: v1.DevlinkParams{Params: []v1.DevlinkParam{
+						{Name: "test", Value: "1", ApplyOn: "VF"},
+					}},
+				},
+				ifaceStatus: &v1.InterfaceExt{
+					NumVfs: 1,
+					DevlinkParams: v1.DevlinkParams{Params: []v1.DevlinkParam{
+						{Name: "test", Value: "1", ApplyOn: "PF"},
+					}},
+					VFs: []v1.VirtualFunction{{}},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "vfio-pci VF is not configured for any group",
 			args: args{
 				ifaceSpec: &v1.Interface{
@@ -1132,6 +1171,72 @@ func TestNeedToUpdateSriov(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := v1.NeedToUpdateSriov(tt.args.ifaceSpec, tt.args.ifaceStatus); got != tt.want {
 				t.Errorf("NeedToUpdateSriov() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedToUpdateDevlinkParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired v1.DevlinkParams
+		current v1.DevlinkParams
+		want    bool
+	}{
+		{
+			name: "empty target and cmode use PF runtime defaults",
+			desired: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1"},
+			}},
+			current: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "PF", Cmode: "runtime"},
+			}},
+			want: false,
+		},
+		{
+			name: "target comparison is case insensitive",
+			desired: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "vf"},
+			}},
+			current: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "VF"},
+			}},
+			want: false,
+		},
+		{
+			name: "value changed",
+			desired: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "2", ApplyOn: "PF"},
+			}},
+			current: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1"},
+			}},
+			want: true,
+		},
+		{
+			name: "target changed",
+			desired: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "VF"},
+			}},
+			current: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "PF"},
+			}},
+			want: true,
+		},
+		{
+			name: "desired parameter missing from status",
+			desired: v1.DevlinkParams{Params: []v1.DevlinkParam{
+				{Name: "test", Value: "1", ApplyOn: "PF"},
+			}},
+			current: v1.DevlinkParams{},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := v1.NeedToUpdateDevlinkParams(&tt.desired, &tt.current); got != tt.want {
+				t.Errorf("NeedToUpdateDevlinkParams() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/doc/design/devlink-params-configuration.md
+++ b/doc/design/devlink-params-configuration.md
@@ -45,6 +45,14 @@ Devlink parameters are configured on OS level by `GenericPlugin`. Since vendor h
 prior to devlink (e.g. `esw_multiport` requires `LAG_RESOURCE_ALLOCATION=1` firmware flag to be set for NVIDIA NICs)
 vendor plugin will go over `DevlinkParams` list to configure firmware if needed.
 
+The generic plugin applies parameters according to `ApplyOn`. When a PF-targeted value is missing or differs from the
+discovered PF value, the operator removes the existing VFs, moves the PF to the requested eSwitch mode, applies PF
+parameters, and then recreates and configures the VFs. VF-targeted parameters are applied after VF configuration and do
+not by themselves rebuild the PF. `flow_steering_mode` is an exception: after VF removal, it is applied while the PF is in
+legacy mode before the PF moves to switchdev. When multiple PFs have changed PF-targeted values, the operator first moves
+every participating PF to its requested eSwitch mode, then applies all changed PF parameters, and only then recreates any
+VFs. This batch-wide barrier lets multi-PF parameters such as `esw_multiport` see every participating PF in switchdev mode.
+
 #### Webhook changes
 TBD
 

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -51,8 +51,10 @@ const (
 )
 
 type interfaceToConfigure struct {
-	Iface       sriovnetworkv1.Interface
-	IfaceStatus sriovnetworkv1.InterfaceExt
+	Iface           sriovnetworkv1.Interface
+	IfaceStatus     sriovnetworkv1.InterfaceExt
+	PFConfigChanged bool
+	PFParamsChanged bool
 }
 
 type sriov struct {
@@ -168,6 +170,15 @@ func (s *sriov) getVfInfo(vfAddr string, pfName string, eswitchMode string, devi
 		Driver:     driver,
 		VfID:       id,
 		VdpaType:   s.vdpaHelper.DiscoverVDPAType(vfAddr),
+	}
+	devlinkParams, err := s.networkHelper.GetDevlinkDeviceParams(vfAddr)
+	if err != nil {
+		log.Log.Error(err, "getVfInfo(): unable to get VF devlink parameters", "device", vfAddr)
+	} else {
+		for i := range devlinkParams {
+			devlinkParams[i].ApplyOn = consts.DevlinkParamApplyOnVf
+		}
+		vf.DevlinkParams.Params = devlinkParams
 	}
 
 	if eswitchMode == sriovnetworkv1.ESwithModeSwitchDev {
@@ -341,6 +352,12 @@ func (s *sriov) DiscoverSriovDevices(storeManager store.ManagerInterface) ([]sri
 			iface.TotalVfs = s.dputilsLib.GetSriovVFcapacity(device.Address)
 			iface.NumVfs = s.dputilsLib.GetVFconfigured(device.Address)
 			iface.EswitchMode = s.GetNicSriovMode(device.Address)
+			devlinkParams, err := s.networkHelper.GetDevlinkDeviceParams(device.Address)
+			if err != nil {
+				log.Log.Error(err, "DiscoverSriovDevices(): unable to get PF devlink parameters, skipping", "device", device)
+			} else {
+				iface.DevlinkParams.Params = devlinkParams
+			}
 			if s.dputilsLib.SriovConfigured(device.Address) {
 				vfs, err := s.dputilsLib.GetVFList(device.Address)
 				if err != nil {
@@ -351,13 +368,6 @@ func (s *sriov) DiscoverSriovDevices(storeManager store.ManagerInterface) ([]sri
 				for _, vf := range vfs {
 					instance := s.getVfInfo(vf, pfNetName, iface.EswitchMode, devices)
 					iface.VFs = append(iface.VFs, instance)
-				}
-				devlinkParams, err := s.networkHelper.GetDevlinkDeviceParams(device.Address)
-				if err != nil {
-					log.Log.Error(err, "DiscoverSriovDevices(): unable devlink parameters, skipping",
-						"device", device)
-				} else {
-					iface.DevlinkParams.Params = devlinkParams
 				}
 			}
 		}
@@ -424,13 +434,13 @@ func (s *sriov) DiscoverSriovVirtualDevices() ([]sriovnetworkv1.InterfaceExt, er
 	return pfList, nil
 }
 
-func (s *sriov) configSriovPFDevice(iface *sriovnetworkv1.Interface) error {
-	log.Log.V(2).Info("configSriovPFDevice(): configure PF sriov device",
+func (s *sriov) configureSriovPFDevice(iface *sriovnetworkv1.Interface, configureVFs func(*sriovnetworkv1.Interface) error) error {
+	log.Log.V(2).Info("configureSriovPFDevice(): configure PF sriov device",
 		"device", iface.PciAddress)
 	totalVfs := s.dputilsLib.GetSriovVFcapacity(iface.PciAddress)
 	if iface.NumVfs > totalVfs {
 		err := fmt.Errorf("cannot config SRIOV device: NumVfs (%d) is larger than TotalVfs (%d)", iface.NumVfs, totalVfs)
-		log.Log.Error(err, "configSriovPFDevice(): fail to set NumVfs for device", "device", iface.PciAddress)
+		log.Log.Error(err, "configureSriovPFDevice(): fail to set NumVfs for device", "device", iface.PciAddress)
 		return err
 	}
 	if err := s.configureHWOptionsForSwitchdev(iface); err != nil {
@@ -440,51 +450,137 @@ func (s *sriov) configSriovPFDevice(iface *sriovnetworkv1.Interface) error {
 	// make sure that rules are always in a consistent state, e.g. there is no
 	// switchdev-related rules for PF in legacy mode
 	if err := s.removeUdevRules(iface.PciAddress); err != nil {
-		log.Log.Error(err, "configSriovPFDevice(): fail to remove udev rules", "device", iface.PciAddress)
+		log.Log.Error(err, "configureSriovPFDevice(): fail to remove udev rules", "device", iface.PciAddress)
 		return err
 	}
 	err := s.addUdevRules(iface)
 	if err != nil {
-		log.Log.Error(err, "configSriovPFDevice(): fail to add udev rules", "device", iface.PciAddress)
+		log.Log.Error(err, "configureSriovPFDevice(): fail to add udev rules", "device", iface.PciAddress)
 		return err
 	}
-	err = s.createVFs(iface)
-	if err != nil {
-		log.Log.Error(err, "configSriovPFDevice(): fail to set NumVfs for device", "device", iface.PciAddress)
+	if err := configureVFs(iface); err != nil {
+		log.Log.Error(err, "configureSriovPFDevice(): fail to configure VFs for device", "device", iface.PciAddress)
 		return err
 	}
 	if err := s.addVfRepresentorUdevRule(iface); err != nil {
-		log.Log.Error(err, "configSriovPFDevice(): fail to add VR representor udev rule", "device", iface.PciAddress)
+		log.Log.Error(err, "configureSriovPFDevice(): fail to add VR representor udev rule", "device", iface.PciAddress)
 		return err
 	}
 	// set PF mtu
 	if iface.Mtu > 0 && iface.Mtu > s.networkHelper.GetNetdevMTU(iface.PciAddress) {
 		err = s.networkHelper.SetNetdevMTU(iface.PciAddress, iface.Mtu)
 		if err != nil {
-			log.Log.Error(err, "configSriovPFDevice(): fail to set mtu for PF", "device", iface.PciAddress)
+			log.Log.Error(err, "configureSriovPFDevice(): fail to set mtu for PF", "device", iface.PciAddress)
 			return err
 		}
 	}
 
-	// Devlink params are applied in ConfigSriovInterfaces() after all interface configuration is complete
 	return nil
 }
 
-func (s *sriov) applyDevlinkPfParam(iface *sriovnetworkv1.Interface, param sriovnetworkv1.DevlinkParam) error {
-	return s.networkHelper.SetDevlinkDeviceParam(iface.PciAddress, param.Name, param.Value)
+func (s *sriov) configSriovPFDevice(iface *sriovnetworkv1.Interface) error {
+	return s.configureSriovPFDevice(iface, s.createVFs)
 }
 
-func (s *sriov) applyDevlinkVfParam(iface *sriovnetworkv1.Interface, param sriovnetworkv1.DevlinkParam) error {
-	vfAddrs, err := s.dputilsLib.GetVFList(iface.PciAddress)
+func (s *sriov) prepareSriovPFDevice(iface *sriovnetworkv1.Interface) error {
+	return s.configureSriovPFDevice(iface, s.preparePFForVFCreation)
+}
+
+func (s *sriov) applyDevlinkPfParam(pciAddress string, param sriovnetworkv1.DevlinkParam) error {
+	if err := s.networkHelper.SetDevlinkDeviceParam(pciAddress, param.Name, param.Value); err != nil {
+		return fmt.Errorf("failed to apply devlink param %q to PF %s: %w", param.Name, pciAddress, err)
+	}
+	return nil
+}
+
+func (s *sriov) applyDevlinkVfParam(pciAddress string, param sriovnetworkv1.DevlinkParam) error {
+	vfAddrs, err := s.dputilsLib.GetVFList(pciAddress)
 	if err != nil {
-		log.Log.Error(err, "applyDevlinkVfParam(): fail to get VF list", "device", iface.PciAddress, "param")
-		return err
+		return fmt.Errorf("failed to get VF list for PF %s while applying devlink param %q: %w", pciAddress, param.Name, err)
 	}
 
 	for _, addr := range vfAddrs {
 		err = s.networkHelper.SetDevlinkDeviceParam(addr, param.Name, param.Value)
 		if err != nil {
-			log.Log.Error(err, "applyDevlinkVfParam(): fail apply devlink param for VF", "device", iface.PciAddress, "param")
+			return fmt.Errorf("failed to apply devlink param %q to VF %s on PF %s: %w", param.Name, addr, pciAddress, err)
+		}
+	}
+
+	return nil
+}
+
+func devlinkParamAppliesTo(param sriovnetworkv1.DevlinkParam, deviceType string) bool {
+	if param.ApplyOn == "" {
+		return deviceType == consts.DevlinkParamApplyOnPf
+	}
+	return strings.EqualFold(param.ApplyOn, deviceType)
+}
+
+func devlinkParamsNeedUpdate(desired, current []sriovnetworkv1.DevlinkParam, deviceType string) bool {
+	for _, desiredParam := range desired {
+		if !devlinkParamAppliesTo(desiredParam, deviceType) {
+			continue
+		}
+
+		found := false
+		for _, currentParam := range current {
+			if !devlinkParamAppliesTo(currentParam, deviceType) ||
+				desiredParam.Name != currentParam.Name {
+				continue
+			}
+
+			found = true
+			if desiredParam.Value != currentParam.Value {
+				return true
+			}
+			break
+		}
+		if !found {
+			return true
+		}
+	}
+	return false
+}
+
+func pfDevlinkParamsNeedUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) bool {
+	return devlinkParamsNeedUpdate(
+		iface.DevlinkParams.Params,
+		ifaceStatus.DevlinkParams.Params,
+		consts.DevlinkParamApplyOnPf,
+	)
+}
+
+func pfConfigurationNeedsUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) bool {
+	if iface.Mtu > 0 && iface.Mtu > ifaceStatus.Mtu {
+		return true
+	}
+	if sriovnetworkv1.GetEswitchModeFromSpec(iface) != sriovnetworkv1.GetEswitchModeFromStatus(ifaceStatus) {
+		return true
+	}
+	if iface.NumVfs != ifaceStatus.NumVfs {
+		return true
+	}
+	return pfDevlinkParamsNeedUpdate(iface, ifaceStatus)
+}
+
+func (s *sriov) applyDevlinkPfParams(pciAddr string, desiredParams, currentParams []sriovnetworkv1.DevlinkParam) error {
+	for _, param := range desiredParams {
+		// flow_steering_mode is applied earlier in configureHWOptionsForSwitchdev,
+		// where the device can be temporarily flipped to legacy eswitch mode if required.
+		if !devlinkParamAppliesTo(param, consts.DevlinkParamApplyOnPf) || param.Name == consts.DevlinkParamFlowSteeringMode {
+			continue
+		}
+		if !devlinkParamsNeedUpdate(
+			[]sriovnetworkv1.DevlinkParam{param},
+			currentParams,
+			consts.DevlinkParamApplyOnPf,
+		) {
+			continue
+		}
+
+		if err := s.applyDevlinkPfParam(pciAddr, param); err != nil {
+			log.Log.Error(err, "applyDevlinkPfParams(): failed to apply devlink param for PF",
+				"device", pciAddr, "param", param.Name)
 			return err
 		}
 	}
@@ -492,41 +588,41 @@ func (s *sriov) applyDevlinkVfParam(iface *sriovnetworkv1.Interface, param sriov
 	return nil
 }
 
-// applyDevlinkParams applies devlink parameters for all configured interfaces.
-// This should be called after all interface configuration is complete (including switchdev mode and VF creation).
-func (s *sriov) applyDevlinkParams(interfaces []interfaceToConfigure) error {
-	log.Log.V(2).Info("applyDevlinkParams(): applying devlink params for configured interfaces")
-	for _, ifaceCfg := range interfaces {
-		iface := &ifaceCfg.Iface
-		if iface.ExternallyManaged {
+func (s *sriov) applyDevlinkVfParams(pciAddr string, devlinkParams []sriovnetworkv1.DevlinkParam) error {
+	for _, param := range devlinkParams {
+		if !devlinkParamAppliesTo(param, consts.DevlinkParamApplyOnVf) {
 			continue
 		}
-		for _, param := range iface.DevlinkParams.Params {
-			// flow_steering_mode is applied earlier in configureHWOptionsForSwitchdev,
-			// where the device can be temporarily flipped to legacy eswitch mode if required.
-			if param.Name == consts.DevlinkParamFlowSteeringMode {
-				continue
-			}
-			var err error
-			switch param.ApplyOn {
-			case consts.DevlinkParamApplyOnPf:
-				err = s.applyDevlinkPfParam(iface, param)
-				if err != nil {
-					log.Log.Error(err, "applyDevlinkParams(): failed to apply devlink param for PF",
-						"device", iface.PciAddress, "param", param.Name)
-					return err
-				}
-			case consts.DevlinkParamApplyOnVf:
-				err = s.applyDevlinkVfParam(iface, param)
-				if err != nil {
-					log.Log.Error(err, "applyDevlinkParams(): failed to apply devlink param for VFs",
-						"device", iface.PciAddress, "param", param.Name)
-					return err
-				}
-			}
+		if err := s.applyDevlinkVfParam(pciAddr, param); err != nil {
+			log.Log.Error(err, "applyDevlinkVfParams(): failed to apply devlink param for VFs",
+				"device", pciAddr, "param", param.Name)
+			return err
 		}
 	}
+
 	return nil
+}
+
+func (s *sriov) preparePFForFlowSteeringChange(iface *sriovnetworkv1.Interface) error {
+	if s.GetNicSriovMode(iface.PciAddress) != sriovnetworkv1.ESwithModeLegacy {
+		if err := s.setEswitchModeAndNumVFs(
+			iface.PciAddress,
+			iface.Name,
+			sriovnetworkv1.ESwithModeLegacy,
+			0,
+		); err != nil {
+			return err
+		}
+	} else if s.dputilsLib.GetVFconfigured(iface.PciAddress) > 0 {
+		if err := s.unbindAllVFsOnPF(iface.PciAddress); err != nil {
+			return err
+		}
+		if err := s.SetSriovNumVfs(iface.PciAddress, 0); err != nil {
+			return err
+		}
+	}
+
+	return s.waitForVFRemoval(iface.PciAddress, 120*time.Second)
 }
 
 func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) error {
@@ -541,10 +637,10 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 	}
 	// Default to smfs unless the user explicitly requests a different mode via devlink params.
 	// flow_steering_mode is special: it must be applied while the device is in legacy eswitch mode,
-	// so we handle it here (not in applyDevlinkParams). applyDevlinkParams skips it accordingly.
+	// so we handle it here (not in applyDevlinkPfParams). applyDevlinkPfParams skips it accordingly.
 	desiredFlowSteeringMode := consts.FlowSteeringModeSmfs
 	for _, p := range iface.DevlinkParams.Params {
-		if p.ApplyOn == consts.DevlinkParamApplyOnPf &&
+		if devlinkParamAppliesTo(p, consts.DevlinkParamApplyOnPf) &&
 			p.Name == consts.DevlinkParamFlowSteeringMode &&
 			p.Value != "" {
 			desiredFlowSteeringMode = p.Value
@@ -569,13 +665,11 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 	if currentFlowSteeringMode == desiredFlowSteeringMode {
 		return nil
 	}
-	// flow steering mode can be changed only when NIC is in legacy mode
-	if s.GetNicSriovMode(iface.PciAddress) != sriovnetworkv1.ESwithModeLegacy {
-		err = s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, sriovnetworkv1.ESwithModeLegacy, 0)
-		if err != nil {
-			log.Log.Error(err, "falied to switch Eswitch mode to legacy and reset number of vfs to 0")
-			return err
-		}
+	// flow_steering_mode must be changed in legacy mode with no VFs present.
+	if err := s.preparePFForFlowSteeringChange(iface); err != nil {
+		log.Log.Error(err, "configureHWOptionsForSwitchdev(): failed to prepare PF for flow steering change",
+			"device", iface.PciAddress)
+		return err
 	}
 	if err := s.networkHelper.SetDevlinkDeviceParam(iface.PciAddress, consts.DevlinkParamFlowSteeringMode, desiredFlowSteeringMode); err != nil {
 		if errors.Is(err, syscall.ENOTSUP) {
@@ -744,36 +838,68 @@ func (s *sriov) configSriovVFDevices(iface *sriovnetworkv1.Interface) error {
 	return nil
 }
 
-func (s *sriov) configSriovDevice(iface *sriovnetworkv1.Interface, skipVFConfiguration bool) error {
-	log.Log.V(2).Info("configSriovDevice(): configure sriov device",
-		"device", iface.PciAddress, "config", iface, "skipVFConfiguration", skipVFConfiguration)
-	if !iface.ExternallyManaged {
-		if err := s.configSriovPFDevice(iface); err != nil {
+func (s *sriov) prepareSriovDevice(iface *interfaceToConfigure) error {
+	log.Log.V(2).Info("prepareSriovDevice(): prepare PF before applying devlink parameters",
+		"device", iface.Iface.PciAddress, "pfParamsChanged", iface.PFParamsChanged)
+	if iface.Iface.ExternallyManaged || !iface.PFParamsChanged {
+		return nil
+	}
+	return s.prepareSriovPFDevice(&iface.Iface)
+}
+
+func (s *sriov) applyChangedPFDevlinkParams(iface *interfaceToConfigure) error {
+	if iface.Iface.ExternallyManaged || !iface.PFParamsChanged {
+		return nil
+	}
+	return s.applyDevlinkPfParams(
+		iface.Iface.PciAddress,
+		iface.Iface.DevlinkParams.Params,
+		iface.IfaceStatus.DevlinkParams.Params,
+	)
+}
+
+func (s *sriov) completeSriovDeviceConfiguration(iface *interfaceToConfigure, skipVFConfiguration bool) error {
+	log.Log.V(2).Info("completeSriovDeviceConfiguration(): configure sriov device",
+		"device", iface.Iface.PciAddress, "config", iface.Iface, "skipVFConfiguration", skipVFConfiguration)
+	if !iface.Iface.ExternallyManaged {
+		var err error
+		if iface.PFParamsChanged {
+			err = s.createVFsAfterPFParams(&iface.Iface)
+		} else if iface.PFConfigChanged {
+			err = s.configSriovPFDevice(&iface.Iface)
+		}
+		if err != nil {
 			return err
 		}
 	}
 	if skipVFConfiguration {
-		if iface.ExternallyManaged {
+		if iface.Iface.ExternallyManaged {
 			return nil
 		}
-		log.Log.V(2).Info("configSriovDevice(): skipVFConfiguration is true, unbind all VFs from drivers",
-			"device", iface.PciAddress)
-		return s.unbindAllVFsOnPF(iface.PciAddress)
+		log.Log.V(2).Info("completeSriovDeviceConfiguration(): skipVFConfiguration is true, unbind all VFs from drivers",
+			"device", iface.Iface.PciAddress)
+		return s.unbindAllVFsOnPF(iface.Iface.PciAddress)
 	}
 	// we don't need to validate externally managed PFs when skipVFConfiguration is true.
 	// The function usually called with skipVFConfiguration true when running in the systemd mode and configuration is
 	// in pre phase. Externally managed PFs may not be configured at this stage yet (preConfig stage is executed before NetworkManager, netplan)
 
-	if iface.ExternallyManaged {
-		if err := s.checkExternallyManagedPF(iface); err != nil {
+	if iface.Iface.ExternallyManaged {
+		if err := s.checkExternallyManagedPF(&iface.Iface); err != nil {
 			return err
 		}
 	}
-	if err := s.configSriovVFDevices(iface); err != nil {
+	if err := s.configSriovVFDevices(&iface.Iface); err != nil {
 		return err
 	}
+	if !iface.Iface.ExternallyManaged {
+		if err := s.applyDevlinkVfParams(iface.Iface.PciAddress, iface.Iface.DevlinkParams.Params); err != nil {
+			return err
+		}
+	}
+
 	// Set PF link up
-	pfLink, err := s.netlinkLib.LinkByName(iface.Name)
+	pfLink, err := s.netlinkLib.LinkByName(iface.Iface.Name)
 	if err != nil {
 		return err
 	}
@@ -791,9 +917,7 @@ func (s *sriov) ConfigSriovInterfaces(storeManager store.ManagerInterface,
 	// Detach PF uplinks and stale VF representors from managed OVS bridges before any
 	// SR-IOV work. Runs unconditionally so it covers the case where a previous daemon
 	// instance was killed (e.g. by nic-configuration.wait gating) after configuring
-	// some PFs: the new instance sees those PFs as already-configured, takes the
-	// early-return in createVFs, and would otherwise leave their pre-reboot OVSDB
-	// entries in place.
+	// some PFs and left their pre-reboot OVSDB entries in place.
 	if vars.ManageSoftwareBridges {
 		for i := range interfaces {
 			iface := &interfaces[i]
@@ -819,7 +943,7 @@ func (s *sriov) ConfigSriovInterfaces(storeManager store.ManagerInterface,
 	}
 	if err != nil {
 		log.Log.Error(err, "cannot configure sriov interfaces")
-		return fmt.Errorf("cannot configure sriov interfaces")
+		return fmt.Errorf("cannot configure sriov interfaces: %w", err)
 	}
 	if sriovnetworkv1.ContainsSwitchdevInterface(interfaces) && len(toBeConfigured) > 0 {
 		// for switchdev devices we create udev rule that renames VF representors
@@ -828,13 +952,6 @@ func (s *sriov) ConfigSriovInterfaces(storeManager store.ManagerInterface,
 			log.Log.Error(err, "cannot reload udev rules")
 			return fmt.Errorf("failed to reload udev rules: %v", err)
 		}
-	}
-
-	// Apply devlink params after all interface configuration is complete.
-	// Some devlink params (e.g. esw_multiport) require switchdev mode and VFs to be ready.
-	if err := s.applyDevlinkParams(toBeConfigured); err != nil {
-		log.Log.Error(err, "cannot apply devlink params")
-		return fmt.Errorf("cannot apply devlink params: %v", err)
 	}
 
 	if vars.ParallelNicConfig {
@@ -868,7 +985,12 @@ func (s *sriov) getConfigureAndReset(storeManager store.ManagerInterface, interf
 				}
 				iface := iface
 				ifaceStatus := ifaceStatus
-				toBeConfigured = append(toBeConfigured, interfaceToConfigure{Iface: iface, IfaceStatus: ifaceStatus})
+				toBeConfigured = append(toBeConfigured, interfaceToConfigure{
+					Iface:           iface,
+					IfaceStatus:     ifaceStatus,
+					PFConfigChanged: !iface.ExternallyManaged && pfConfigurationNeedsUpdate(&iface, &ifaceStatus),
+					PFParamsChanged: !iface.ExternallyManaged && pfDevlinkParamsNeedUpdate(&iface, &ifaceStatus),
+				})
 			}
 		}
 
@@ -879,44 +1001,84 @@ func (s *sriov) getConfigureAndReset(storeManager store.ManagerInterface, interf
 	return toBeConfigured, toBeResetted, nil
 }
 
-func (s *sriov) configSriovInterfacesInParallel(storeManager store.ManagerInterface, interfaces []interfaceToConfigure, skipVFConfiguration bool) error {
-	log.Log.V(2).Info("configSriovInterfacesInParallel(): start sriov configuration")
+func (s *sriov) resetAfterConfigError(iface *interfaceToConfigure, configErr error) error {
+	if iface.Iface.ExternallyManaged {
+		log.Log.V(2).Info("resetAfterConfigError(): skipping device reset as the NIC is externally managed",
+			"address", iface.Iface.PciAddress)
+		return configErr
+	}
+	if resetErr := s.ResetSriovDevice(iface.IfaceStatus); resetErr != nil {
+		log.Log.Error(resetErr, "resetAfterConfigError(): failed to reset SR-IOV interface",
+			"address", iface.Iface.PciAddress)
+		return errors.Join(configErr, resetErr)
+	}
+	return configErr
+}
 
-	var result error
-	errChannel := make(chan error)
-	interfacesToConfigure := 0
-	for ifaceIndex, iface := range interfaces {
-		interfacesToConfigure += 1
+func (s *sriov) resetPFParamBatchAfterError(interfaces []interfaceToConfigure, configErr error) error {
+	result := configErr
+	for i := range interfaces {
+		iface := &interfaces[i]
+		if iface.Iface.ExternallyManaged || !iface.PFParamsChanged {
+			continue
+		}
+		if resetErr := s.ResetSriovDevice(iface.IfaceStatus); resetErr != nil {
+			log.Log.Error(resetErr, "resetPFParamBatchAfterError(): failed to reset SR-IOV interface",
+				"address", iface.Iface.PciAddress)
+			result = errors.Join(result, resetErr)
+		}
+	}
+	return result
+}
+
+func (s *sriov) runSriovConfigPhaseInParallel(
+	interfaces []interfaceToConfigure,
+	phaseName string,
+	configure func(*interfaceToConfigure) error,
+) error {
+	errChannel := make(chan error, len(interfaces))
+	for ifaceIndex := range interfaces {
 		go func(iface *interfaceToConfigure) {
-			var err error
-			if err = s.configSriovDevice(&iface.Iface, skipVFConfiguration); err != nil {
-				log.Log.Error(err, "configSriovInterfacesInParallel(): fail to configure sriov interface. resetting interface.", "address", iface.Iface.PciAddress)
-				if iface.Iface.ExternallyManaged {
-					log.Log.V(2).Info("configSriovInterfacesInParallel(): skipping device reset as the nic is marked as externally created")
-				} else {
-					if resetErr := s.ResetSriovDevice(iface.IfaceStatus); resetErr != nil {
-						log.Log.Error(resetErr, "configSriovInterfacesInParallel(): failed to reset on error SR-IOV interface")
-						err = resetErr
-					}
-				}
+			err := configure(iface)
+			if err != nil {
+				log.Log.Error(err, "runSriovConfigPhaseInParallel(): phase failed",
+					"phase", phaseName, "address", iface.Iface.PciAddress)
 			}
 			errChannel <- err
 		}(&interfaces[ifaceIndex])
-		// Save the PF status to the host
-		err := storeManager.SaveLastPfAppliedStatus(&iface.Iface)
-		if err != nil {
+	}
+
+	var result error
+	for range interfaces {
+		result = errors.Join(result, <-errChannel)
+	}
+	return result
+}
+
+func (s *sriov) configSriovInterfacesInParallel(storeManager store.ManagerInterface, interfaces []interfaceToConfigure, skipVFConfiguration bool) error {
+	log.Log.V(2).Info("configSriovInterfacesInParallel(): start sriov configuration")
+
+	if err := s.runSriovConfigPhaseInParallel(interfaces, "prepare PFs", s.prepareSriovDevice); err != nil {
+		return s.resetPFParamBatchAfterError(interfaces, err)
+	}
+	if err := s.runSriovConfigPhaseInParallel(interfaces, "apply PF devlink parameters", s.applyChangedPFDevlinkParams); err != nil {
+		return s.resetPFParamBatchAfterError(interfaces, err)
+	}
+	if err := s.runSriovConfigPhaseInParallel(interfaces, "configure VFs", func(iface *interfaceToConfigure) error {
+		err := s.completeSriovDeviceConfiguration(iface, skipVFConfiguration)
+		if err != nil && !iface.PFParamsChanged {
+			return s.resetAfterConfigError(iface, err)
+		}
+		return err
+	}); err != nil {
+		return s.resetPFParamBatchAfterError(interfaces, err)
+	}
+
+	for i := range interfaces {
+		if err := storeManager.SaveLastPfAppliedStatus(&interfaces[i].Iface); err != nil {
 			log.Log.Error(err, "configSriovInterfacesInParallel(): failed to save PF applied config to host")
 			return err
 		}
-	}
-
-	for i := 0; i < interfacesToConfigure; i++ {
-		errMsg := <-errChannel
-		result = errors.Join(result, errMsg)
-	}
-	if result != nil {
-		log.Log.Error(result, "configSriovInterfacesInParallel(): fail to configure sriov interfaces")
-		return result
 	}
 	log.Log.V(2).Info("configSriovInterfacesInParallel(): sriov configuration finished")
 	return nil
@@ -952,26 +1114,40 @@ func (s *sriov) resetSriovInterfacesInParallel(storeManager store.ManagerInterfa
 
 func (s *sriov) configSriovInterfaces(storeManager store.ManagerInterface, interfaces []interfaceToConfigure, skipVFConfiguration bool) error {
 	log.Log.V(2).Info("configSriovInterfaces(): start sriov configuration")
-	for _, iface := range interfaces {
-		if err := s.configSriovDevice(&iface.Iface, skipVFConfiguration); err != nil {
-			log.Log.Error(err, "configSriovInterfaces(): fail to configure sriov interface. resetting interface.", "address", iface.Iface.PciAddress)
-			if iface.Iface.ExternallyManaged {
-				log.Log.V(2).Info("configSriovInterfaces(): skipping device reset as the nic is marked as externally created")
-			} else {
-				if resetErr := s.ResetSriovDevice(iface.IfaceStatus); resetErr != nil {
-					log.Log.Error(resetErr, "configSriovInterfaces(): failed to reset on error SR-IOV interface")
-				}
-			}
-			return err
+	for i := range interfaces {
+		if err := s.prepareSriovDevice(&interfaces[i]); err != nil {
+			log.Log.Error(err, "configSriovInterfaces(): failed to prepare SR-IOV interface",
+				"address", interfaces[i].Iface.PciAddress)
+			return s.resetPFParamBatchAfterError(interfaces[:i+1], err)
 		}
+	}
 
-		// Save the PF status to the host
-		err := storeManager.SaveLastPfAppliedStatus(&iface.Iface)
-		if err != nil {
+	for i := range interfaces {
+		if err := s.applyChangedPFDevlinkParams(&interfaces[i]); err != nil {
+			log.Log.Error(err, "configSriovInterfaces(): failed to apply PF devlink parameters",
+				"address", interfaces[i].Iface.PciAddress)
+			return s.resetPFParamBatchAfterError(interfaces, err)
+		}
+	}
+
+	for i := range interfaces {
+		if err := s.completeSriovDeviceConfiguration(&interfaces[i], skipVFConfiguration); err != nil {
+			log.Log.Error(err, "configSriovInterfaces(): failed to complete SR-IOV interface configuration",
+				"address", interfaces[i].Iface.PciAddress)
+			if !interfaces[i].PFParamsChanged {
+				err = s.resetAfterConfigError(&interfaces[i], err)
+			}
+			return s.resetPFParamBatchAfterError(interfaces, err)
+		}
+	}
+
+	for i := range interfaces {
+		if err := storeManager.SaveLastPfAppliedStatus(&interfaces[i].Iface); err != nil {
 			log.Log.Error(err, "configSriovInterfaces(): failed to save PF applied config to host")
 			return err
 		}
 	}
+
 	log.Log.V(2).Info("configSriovInterfaces(): sriov configuration finished")
 	return nil
 }
@@ -1253,7 +1429,41 @@ func (s *sriov) removeUdevRules(pciAddress string) error {
 	return s.udevHelper.RemovePersistPFNameUdevRule(pciAddress)
 }
 
-// create VFs on the PF
+// preparePFForVFCreation removes existing VFs and moves the PF into the requested eSwitch mode.
+// PF devlink parameters are applied after this step and before the VFs are recreated.
+func (s *sriov) preparePFForVFCreation(iface *sriovnetworkv1.Interface) error {
+	desiredEswitchMode := sriovnetworkv1.GetEswitchModeFromSpec(iface)
+	currentEswitchMode := s.GetNicSriovMode(iface.PciAddress)
+	configuredVFs := s.dputilsLib.GetVFconfigured(iface.PciAddress)
+
+	if currentEswitchMode == sriovnetworkv1.ESwithModeSwitchDev {
+		if err := s.detachPFFromBridge(iface.PciAddress, iface.Name, iface.NumVfs); err != nil {
+			return err
+		}
+	}
+	if configuredVFs > 0 {
+		if err := s.unbindAllVFsOnPF(iface.PciAddress); err != nil {
+			return err
+		}
+		if err := s.SetSriovNumVfs(iface.PciAddress, 0); err != nil {
+			return err
+		}
+	}
+	// VF destruction is asynchronous. This wait is required even when sriov_numvfs
+	// already reports zero, because flow_steering_mode may have reset the VFs just
+	// before this function and stale virtfn links can still be present.
+	if err := s.waitForVFRemoval(iface.PciAddress, 120*time.Second); err != nil {
+		return err
+	}
+	if currentEswitchMode != desiredEswitchMode {
+		if err := s.SetNicSriovMode(iface.PciAddress, desiredEswitchMode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createVFs preserves the driver-specific eSwitch/VF creation order for ordinary topology changes.
 func (s *sriov) createVFs(iface *sriovnetworkv1.Interface) error {
 	expectedEswitchMode := sriovnetworkv1.GetEswitchModeFromSpec(iface)
 	log.Log.V(2).Info("createVFs(): configure VFs for device",
@@ -1267,6 +1477,43 @@ func (s *sriov) createVFs(iface *sriovnetworkv1.Interface) error {
 		}
 	}
 	return s.setEswitchModeAndNumVFs(iface.PciAddress, iface.Name, expectedEswitchMode, iface.NumVfs)
+}
+
+// createVFsAfterPFParams creates VFs after the PF mode and changed PF devlink parameters are configured.
+func (s *sriov) createVFsAfterPFParams(iface *sriovnetworkv1.Interface) error {
+	log.Log.V(2).Info("createVFsAfterPFParams(): configure VFs for device",
+		"device", iface.PciAddress, "count", iface.NumVfs)
+	if iface.NumVfs == 0 {
+		return nil
+	}
+	if err := s.SetSriovNumVfs(iface.PciAddress, iface.NumVfs); err != nil {
+		return err
+	}
+	return s.waitForVFLinks(iface.PciAddress, iface.NumVfs, 120*time.Second)
+}
+
+func (s *sriov) waitForVFRemoval(pciAddr string, maxTimeout time.Duration) error {
+	log.Log.V(2).Info("waitForVFRemoval(): waiting for VF symlinks to be removed",
+		"device", pciAddr, "maxTimeout", maxTimeout)
+
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		time.Second,
+		maxTimeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			vfAddrs, err := s.dputilsLib.GetVFList(pciAddr)
+			if err != nil {
+				log.Log.V(2).Info("waitForVFRemoval(): GetVFList failed, retrying", "device", pciAddr, "err", err)
+				return false, nil
+			}
+			return len(vfAddrs) == 0, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("timeout waiting for VF removal on %s (max %v): %w", pciAddr, maxTimeout, err)
+	}
+	return nil
 }
 
 type setEswitchModeAndNumVFsFn func(string, string, string, int) error

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	dputilsMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/dputils/mock"
 	ghwMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/ghw/mock"
 	netlinkMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/netlink/mock"
@@ -117,6 +118,9 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("mlx5_core", nil)
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil)
 			hostMock.EXPECT().DiscoverVDPAType("0000:d8:00.2").Return("")
+			hostMock.EXPECT().GetDevlinkDeviceParams("0000:d8:00.2").Return([]sriovnetworkv1.DevlinkParam{
+				{Name: "enable_roce", Value: "true", Cmode: "runtime"},
+			}, nil)
 
 			hostMock.EXPECT().TryGetInterfaceName("0000:d8:00.2").Return("enp216s0f0v0")
 			vfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
@@ -165,6 +169,9 @@ var _ = Describe("SRIOV", func() {
 					VfID:            0,
 					RepresentorName: "enp216s0f0np0_0",
 					GUID:            "guid1",
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "enable_roce", Value: "true", Cmode: "runtime", ApplyOn: "VF"},
+					}},
 				}},
 				DevlinkParams: sriovnetworkv1.DevlinkParams{
 					Params: []sriovnetworkv1.DevlinkParam{
@@ -236,6 +243,55 @@ var _ = Describe("SRIOV", func() {
 		})
 	})
 
+	DescribeTable("classifies devlink params by target device",
+		func(applyOn, deviceType string, expected bool) {
+			param := sriovnetworkv1.DevlinkParam{ApplyOn: applyOn}
+			Expect(devlinkParamAppliesTo(param, deviceType)).To(Equal(expected))
+		},
+		Entry("empty defaults to PF", "", "PF", true),
+		Entry("empty does not target VF", "", "VF", false),
+		Entry("uppercase PF", "PF", "PF", true),
+		Entry("lowercase PF", "pf", "PF", true),
+		Entry("uppercase VF", "VF", "VF", true),
+		Entry("lowercase VF", "vf", "VF", true),
+		Entry("uppercase SF", "SF", "SF", true),
+		Entry("lowercase SF", "sf", "SF", true),
+		Entry("PF does not target VF", "PF", "VF", false),
+	)
+
+	DescribeTable("detects target-specific devlink parameter changes",
+		func(desired, current []sriovnetworkv1.DevlinkParam, deviceType string, expected bool) {
+			Expect(devlinkParamsNeedUpdate(desired, current, deviceType)).To(Equal(expected))
+		},
+		Entry("missing PF parameter", []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "1", ApplyOn: "PF"}}, nil, "PF", true),
+		Entry("changed PF value", []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "1", ApplyOn: "PF"}}, []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "0", ApplyOn: "pf"}}, "PF", true),
+		Entry("matching PF parameter", []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "1"}}, []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "1", ApplyOn: "pf"}}, "PF", false),
+		Entry("VF-only change is ignored for PF", []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "1", ApplyOn: "VF"}}, []sriovnetworkv1.DevlinkParam{{Name: "test", Value: "0", ApplyOn: "vf"}}, "PF", false),
+	)
+
+	It("requires a PF rebuild for PF devlink changes but not VF-only changes", func() {
+		status := &sriovnetworkv1.InterfaceExt{
+			NumVfs:      1,
+			EswitchMode: sriovnetworkv1.ESwithModeLegacy,
+			DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+				{Name: "pf_param", Value: "old", ApplyOn: "PF"},
+				{Name: "vf_param", Value: "old", ApplyOn: "VF"},
+			}},
+		}
+		iface := &sriovnetworkv1.Interface{
+			NumVfs:      1,
+			EswitchMode: sriovnetworkv1.ESwithModeLegacy,
+			DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+				{Name: "pf_param", Value: "new", ApplyOn: "pf"},
+				{Name: "vf_param", Value: "new", ApplyOn: "vf"},
+			}},
+		}
+
+		Expect(pfDevlinkParamsNeedUpdate(iface, status)).To(BeTrue())
+		iface.DevlinkParams.Params[0].Value = "old"
+		Expect(pfDevlinkParamsNeedUpdate(iface, status)).To(BeFalse())
+	})
+
 	Context("ConfigSriovInterfaces", func() {
 		It("should configure", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
@@ -249,22 +305,31 @@ var _ = Describe("SRIOV", func() {
 			})
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
-			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(2)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
 				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil).AnyTimes()
+			pf0ParamApplied := hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "pf_param", "pf0").Return(nil)
+			vfListCalls := 0
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").DoAndReturn(func(string) ([]string, error) {
+				vfListCalls++
+				if vfListCalls == 2 {
+					return []string{}, nil
+				}
+				return []string{"0000:d8:00.2", "0000:d8:00.3"}, nil
+			}).AnyTimes()
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().Unbind("0000:d8:00.3").Return(nil)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(3)
 			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2).After(pf0ParamApplied)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -281,7 +346,9 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.3").Return(1, nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.3").Return(true, "vfio-pci").Times(2)
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.3", false).Return(nil)
-			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
+			pf0VFsConfigured := hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.2", "vf_param", "true").Return(nil).After(pf0VFsConfigured)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.3", "vf_param", "true").Return(nil).After(pf0VFsConfigured)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
@@ -295,6 +362,10 @@ var _ = Describe("SRIOV", func() {
 					Name:       "enp216s0f0np0",
 					PciAddress: "0000:d8:00.0",
 					NumVfs:     2,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "pf0", ApplyOn: "PF"},
+						{Name: "vf_param", Value: "true", ApplyOn: "VF"},
+					}},
 					VfGroups: []sriovnetworkv1.VfGroup{
 						{
 							VfRange:      "0-0",
@@ -312,9 +383,210 @@ var _ = Describe("SRIOV", func() {
 							DeviceType:   "vfio-pci",
 						}},
 				}},
-				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}, {PciAddress: "0000:d8:00.1"}},
+				[]sriovnetworkv1.InterfaceExt{{
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      2,
+					EswitchMode: sriovnetworkv1.ESwithModeLegacy,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "old", ApplyOn: "PF"},
+					}},
+				}, {PciAddress: "0000:d8:00.1"}},
 				false)).NotTo(HaveOccurred())
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "2")
+		})
+
+		It("prepares every PF before applying any PF devlink parameter in serial", func() {
+			interfaces := []interfaceToConfigure{
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np0",
+						PciAddress: "0000:d8:00.0",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf0", ApplyOn: "PF"},
+						}},
+					},
+					PFParamsChanged: true,
+				},
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np1",
+						PciAddress: "0000:d8:00.1",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf1", ApplyOn: "PF"},
+						}},
+					},
+					PFParamsChanged: true,
+				},
+			}
+
+			expectPreparation := func(pciAddress string) *gomock.Call {
+				dputilsLibMock.EXPECT().GetSriovVFcapacity(pciAddress).Return(0)
+				netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", pciAddress).Return(&netlink.DevlinkDevice{
+					Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
+				hostMock.EXPECT().RemoveDisableNMUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().RemovePersistPFNameUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().RemoveVfRepresentorUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().AddDisableNMUdevRule(pciAddress).Return(nil)
+				dputilsLibMock.EXPECT().GetVFconfigured(pciAddress).Return(0)
+				return dputilsLibMock.EXPECT().GetVFList(pciAddress).Return([]string{}, nil)
+			}
+
+			pf0Prepared := expectPreparation("0000:d8:00.0")
+			pf1Prepared := expectPreparation("0000:d8:00.1")
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "pf_param", "pf0").Return(nil).After(pf0Prepared).After(pf1Prepared)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.1", "pf_param", "pf1").Return(nil).After(pf0Prepared).After(pf1Prepared)
+
+			pf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pf0LinkMock, nil)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pf0LinkMock).Return(true)
+			pf1LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np1").Return(pf1LinkMock, nil)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pf1LinkMock).Return(true)
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil).Times(2)
+
+			Expect(s.(*sriov).configSriovInterfaces(storeManagerMode, interfaces, false)).NotTo(HaveOccurred())
+		})
+
+		It("aborts the PF devlink phase when any parallel PF preparation fails", func() {
+			interfaces := []interfaceToConfigure{
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np0",
+						PciAddress: "0000:d8:00.0",
+						NumVfs:     1,
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf0", ApplyOn: "PF"},
+						}},
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.0",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np1",
+						PciAddress: "0000:d8:00.1",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf1", ApplyOn: "PF"},
+						}},
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.1",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+			}
+
+			// PF0 fails capacity validation. PF1 may prepare concurrently, but the
+			// batch barrier must prevent every PF devlink write and VF recreation.
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(0)
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.1").Return(0)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.1").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
+			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
+			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
+			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.1").Return(nil)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.1").Return(0)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.1").Return([]string{}, nil)
+
+			// Both PF-param participants are reset after the failed batch.
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.0", 2048).Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.1", 2048).Return(nil)
+
+			Expect(s.(*sriov).configSriovInterfacesInParallel(storeManagerMode, interfaces, false)).To(HaveOccurred())
+		})
+
+		It("does not reset unattempted PFs after a serial preparation failure", func() {
+			interfaces := []interfaceToConfigure{
+				{
+					Iface: sriovnetworkv1.Interface{
+						PciAddress: "0000:d8:00.0",
+						NumVfs:     1,
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.0",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+				{
+					Iface: sriovnetworkv1.Interface{
+						PciAddress: "0000:d8:00.1",
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.1",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+			}
+
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(0)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.0", 2048).Return(nil)
+
+			Expect(s.(*sriov).configSriovInterfaces(storeManagerMode, interfaces, false)).To(HaveOccurred())
+		})
+
+		It("resets every prepared PF when serial VF completion fails", func() {
+			interfaces := []interfaceToConfigure{
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np0",
+						PciAddress: "0000:d8:00.0",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf0", ApplyOn: "PF"},
+						}},
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.0",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+				{
+					Iface: sriovnetworkv1.Interface{
+						Name:       "enp216s0f0np1",
+						PciAddress: "0000:d8:00.1",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf1", ApplyOn: "PF"},
+						}},
+					},
+					IfaceStatus: sriovnetworkv1.InterfaceExt{
+						PciAddress: "0000:d8:00.1",
+						LinkType:   consts.LinkTypeIB,
+					},
+					PFParamsChanged: true,
+				},
+			}
+
+			expectPreparation := func(pciAddress string) {
+				dputilsLibMock.EXPECT().GetSriovVFcapacity(pciAddress).Return(0)
+				netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", pciAddress).Return(&netlink.DevlinkDevice{
+					Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
+				hostMock.EXPECT().RemoveDisableNMUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().RemovePersistPFNameUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().RemoveVfRepresentorUdevRule(pciAddress).Return(nil)
+				hostMock.EXPECT().AddDisableNMUdevRule(pciAddress).Return(nil)
+				dputilsLibMock.EXPECT().GetVFconfigured(pciAddress).Return(0)
+				dputilsLibMock.EXPECT().GetVFList(pciAddress).Return([]string{}, nil)
+			}
+
+			expectPreparation("0000:d8:00.0")
+			expectPreparation("0000:d8:00.1")
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "pf_param", "pf0").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.1", "pf_param", "pf1").Return(nil)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(nil, testError)
+
+			// PF1 has not entered completion yet, but it was already prepared and
+			// must be rolled back with PF0 after the batch failure.
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.0", 2048).Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.1", 2048).Return(nil)
+
+			Expect(s.(*sriov).configSriovInterfaces(storeManagerMode, interfaces, false)).To(HaveOccurred())
 		})
 
 		It("should configure in parallel", func() {
@@ -339,23 +611,31 @@ var _ = Describe("SRIOV", func() {
 				},
 			})
 
+			pf1Prepared := dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.1").Return(0)
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
-			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
+			pf0Prepared := dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
 				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil).AnyTimes()
+			pf0ParamApplied := hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "pf_param", "pf0").Return(nil).After(pf0Prepared).After(pf1Prepared)
+			pf0VFListCalls := 0
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").DoAndReturn(func(string) ([]string, error) {
+				pf0VFListCalls++
+				if pf0VFListCalls == 1 {
+					return []string{}, nil
+				}
+				return []string{"0000:d8:00.2", "0000:d8:00.3"}, nil
+			}).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(3)
 			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2).After(pf0ParamApplied)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -372,25 +652,33 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.3").Return(1, nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.3").Return(true, "vfio-pci").Times(2)
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.3", false).Return(nil)
-			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
+			pf0VFsConfigured := hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.2", "vf_param", "true").Return(nil).After(pf0VFsConfigured)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.3", "vf_param", "true").Return(nil).After(pf0VFsConfigured)
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.1").Return(2)
-			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.1").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.1").Return("mlx5_core", nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.1").Return(&netlink.DevlinkDevice{
 				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.1").Return(nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.1").Return([]string{"0000:d8:00.4", "0000:d8:00.5"}, nil).AnyTimes()
+			pf1ParamApplied := hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.1", "pf_param", "pf1").Return(nil).After(pf0Prepared).After(pf1Prepared)
+			pf1VFListCalls := 0
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.1").DoAndReturn(func(string) ([]string, error) {
+				pf1VFListCalls++
+				if pf1VFListCalls == 1 {
+					return []string{}, nil
+				}
+				return []string{"0000:d8:00.4", "0000:d8:00.5"}, nil
+			}).AnyTimes()
 			pf1LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np1").Return(pf1LinkMock, nil).Times(3)
 			pf1LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pf1LinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pf1LinkMock).Return(nil)
 
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.4").Return(0, nil).Times(2)
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.4").Return(0, nil).Times(2).After(pf1ParamApplied)
 			hostMock.EXPECT().HasDriver("0000:d8:00.4").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.4").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.4").Return(true, "test")
@@ -407,7 +695,9 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.5").Return(1, nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.5").Return(true, "vfio-pci").Times(2)
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.5", false).Return(nil)
-			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.5", "vfio-pci").Return(nil)
+			pf1VFsConfigured := hostMock.EXPECT().BindDpdkDriver("0000:d8:00.5", "vfio-pci").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.4", "vf_param", "true").Return(nil).After(pf1VFsConfigured)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.5", "vf_param", "true").Return(nil).After(pf1VFsConfigured)
 
 			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil).Times(2)
 
@@ -417,6 +707,10 @@ var _ = Describe("SRIOV", func() {
 					Name:       "enp216s0f0np0",
 					PciAddress: "0000:d8:00.0",
 					NumVfs:     2,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "pf0", ApplyOn: "PF"},
+						{Name: "vf_param", Value: "true", ApplyOn: "vf"},
+					}},
 					VfGroups: []sriovnetworkv1.VfGroup{
 						{
 							VfRange:      "0-0",
@@ -438,6 +732,10 @@ var _ = Describe("SRIOV", func() {
 						Name:       "enp216s0f0np1",
 						PciAddress: "0000:d8:00.1",
 						NumVfs:     2,
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "pf_param", Value: "pf1", ApplyOn: "pf"},
+							{Name: "vf_param", Value: "true", ApplyOn: "VF"},
+						}},
 						VfGroups: []sriovnetworkv1.VfGroup{
 							{
 								VfRange:      "0-0",
@@ -724,7 +1022,7 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
-		It("should configure configure swtichdev by switching back to legacy mode and configure smfs", func() {
+		It("should configure switchdev by switching back to legacy mode and configure smfs", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
@@ -741,19 +1039,25 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("test", nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
+			oldVFsListed := dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
+			vfsRemoved := dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{}, nil).After(oldVFsListed)
+			flowSteeringApplied := hostMock.EXPECT().SetDevlinkDeviceParam(
+				"0000:d8:00.0", "flow_steering_mode", "smfs").Return(nil).After(vfsRemoved)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return(
+				[]string{"0000:d8:00.2"}, nil).AnyTimes().After(flowSteeringApplied)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(6)
-			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(3)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeLegacy}}}, nil).Times(2)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
-			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode", "smfs").Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(3)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(2)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -796,7 +1100,7 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
-		It("should apply user-supplied flow_steering_mode=hmfs from devlinkParams and skip it in applyDevlinkParams", func() {
+		It("should apply user-supplied flow_steering_mode=hmfs from devlinkParams and skip it in applyDevlinkPfParams", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
@@ -805,7 +1109,7 @@ var _ = Describe("SRIOV", func() {
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil).Times(2)
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -815,20 +1119,28 @@ var _ = Describe("SRIOV", func() {
 			// Device is in switchdev with smfs; user requested hmfs via devlinkParams,
 			// so the operator must flip back to legacy, set hmfs, then return to switchdev.
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("smfs", nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
+			oldVFsListed := dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
+			vfsRemovedBeforeFlow := dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{}, nil).After(oldVFsListed)
+			flowSteeringApplied := hostMock.EXPECT().SetDevlinkDeviceParam(
+				"0000:d8:00.0", "flow_steering_mode", "hmfs").Return(nil).After(vfsRemovedBeforeFlow)
+			vfsStillRemoved := dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return(
+				[]string{}, nil).After(flowSteeringApplied)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return(
+				[]string{"0000:d8:00.2"}, nil).AnyTimes().After(vfsStillRemoved)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
-				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(6)
-			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil).Times(2)
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}}}, nil).Times(3)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "legacy").Return(nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeLegacy}}}, nil).Times(2)
 			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
-			// flow_steering_mode is applied here, NOT later in applyDevlinkParams.
-			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode", "hmfs").Return(nil)
+			// flow_steering_mode was applied after VF removal above, not later in applyDevlinkPfParams.
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil).Times(3)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
@@ -847,7 +1159,7 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
 			hostMock.EXPECT().LoadUdevRules().Return(nil)
 
-			// esw_multiport is applied normally by applyDevlinkParams; flow_steering_mode is NOT
+			// esw_multiport is applied normally by applyDevlinkPfParams; flow_steering_mode is NOT
 			// re-applied here (note the absence of a second SetDevlinkDeviceParam expectation for it).
 			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "esw_multiport", "true").Return(nil)
 
@@ -882,8 +1194,11 @@ var _ = Describe("SRIOV", func() {
 
 		It("should configure switchdev on ice driver", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
-				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files: map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+				Symlinks: map[string]string{
+					"/sys/bus/pci/devices/0000:d8:00.2/physfn": "../../0000:d8:00.0",
+				},
 			})
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
@@ -896,7 +1211,7 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("", syscall.EINVAL)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
@@ -994,6 +1309,33 @@ var _ = Describe("SRIOV", func() {
 				}},
 				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
 				false)).To(HaveOccurred())
+		})
+
+		It("does not mutate devlink params on an externally managed interface", func() {
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			hostMock.EXPECT().GetNetdevMTU("0000:d8:00.0").Return(0)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
+				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
+				nil)
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
+			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+
+			Expect(s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:              "enp216s0f0np0",
+					PciAddress:        "0000:d8:00.0",
+					NumVfs:            0,
+					ExternallyManaged: true,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "new", ApplyOn: "PF"},
+						{Name: "vf_param", Value: "new", ApplyOn: "VF"},
+					}},
+				}},
+				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
+				false)).NotTo(HaveOccurred())
 		})
 
 		It("reset device", func() {
@@ -1121,7 +1463,6 @@ var _ = Describe("SRIOV", func() {
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
 				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
 				nil)
@@ -1129,7 +1470,15 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil).AnyTimes()
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "pf_param", "new").Return(nil)
+			vfListCalls := 0
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").DoAndReturn(func(string) ([]string, error) {
+				vfListCalls++
+				if vfListCalls == 1 {
+					return []string{}, nil
+				}
+				return []string{"0000:d8:00.2", "0000:d8:00.3"}, nil
+			}).AnyTimes()
 			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().Unbind("0000:d8:00.3").Return(nil)
 
@@ -1140,6 +1489,10 @@ var _ = Describe("SRIOV", func() {
 					Name:       "enp216s0f0np0",
 					PciAddress: "0000:d8:00.0",
 					NumVfs:     2,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "new"},
+						{Name: "vf_param", Value: "new", ApplyOn: "VF"},
+					}},
 					VfGroups: []sriovnetworkv1.VfGroup{
 						{
 							VfRange:      "0-0",
@@ -1162,7 +1515,67 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "2")
 		})
 
-		It("should apply devlink params after all interface configuration is complete", func() {
+		It("does not rebuild VFs when only a VF devlink param changes", func() {
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs: []string{
+					"/sys/bus/pci/devices/0000:d8:00.0",
+					"/sys/bus/pci/devices/0000:d8:00.2",
+				},
+				Symlinks: map[string]string{
+					"/sys/bus/pci/devices/0000:d8:00.2/physfn": "../../0000:d8:00.0",
+				},
+			})
+
+			// The observed steering mode is not the implicit smfs default. A VF-only
+			// update must not run PF/HW configuration or tear down the existing VF.
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).Times(2)
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "vfio-pci").Times(2)
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", false).Return(nil)
+			hostMock.EXPECT().DeleteVDPADevice("0000:d8:00.2").Return(nil)
+			vfConfigured := hostMock.EXPECT().BindDpdkDriver("0000:d8:00.2", "vfio-pci").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.2", "vf_param", "new").Return(nil).After(vfConfigured)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
+			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
+			hostMock.EXPECT().LoadUdevRules().Return(nil)
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+
+			Expect(s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:        "enp216s0f0np0",
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					LinkType:    "ETH",
+					EswitchMode: sriovnetworkv1.ESwithModeSwitchDev,
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "same", ApplyOn: "PF"},
+						{Name: "vf_param", Value: "new", ApplyOn: "VF"},
+					}},
+					VfGroups: []sriovnetworkv1.VfGroup{{VfRange: "0-0", DeviceType: "vfio-pci"}},
+				}},
+				[]sriovnetworkv1.InterfaceExt{{
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					EswitchMode: sriovnetworkv1.ESwithModeSwitchDev,
+					VFs: []sriovnetworkv1.VirtualFunction{{
+						VfID:   0,
+						Driver: "",
+						DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+							{Name: "vf_param", Value: "old", ApplyOn: "VF"},
+						}},
+					}},
+					DevlinkParams: sriovnetworkv1.DevlinkParams{Params: []sriovnetworkv1.DevlinkParam{
+						{Name: "pf_param", Value: "same", ApplyOn: "pf"},
+						{Name: "flow_steering_mode", Value: "hmfs", ApplyOn: "PF"},
+						{Name: "vf_param", Value: "old", ApplyOn: "vf"},
+					}},
+				}},
+				false)).NotTo(HaveOccurred())
+		})
+
+		It("applies PF params after switchdev and VF params after VF configuration", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
 				Files: map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
@@ -1173,7 +1586,6 @@ var _ = Describe("SRIOV", func() {
 
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
-			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
 			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
 			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
@@ -1181,37 +1593,42 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
 			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("smfs", nil)
-			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
+			vfListCalls := 0
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").DoAndReturn(func(string) ([]string, error) {
+				vfListCalls++
+				if vfListCalls == 1 {
+					return []string{}, nil
+				}
+				return []string{"0000:d8:00.2"}, nil
+			}).AnyTimes()
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
 			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
 				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
-			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
+			switchdevConfigured := netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
+			hostMock.EXPECT().GetPhysPortName("enp216s0f0np0").Return("p0", nil)
+			hostMock.EXPECT().GetPhysSwitchID("enp216s0f0np0").Return("7cfe90ff2cc0", nil)
+			pfConfigured := hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil).After(switchdevConfigured)
+			pfParamApplied := hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "esw_multiport", "true").Return(nil).After(pfConfigured)
 
-			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2).After(pfParamApplied)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
 			hostMock.EXPECT().DeleteVDPADevice("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
-			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
+			vfConfigured := hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
 			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.2").Return(42, nil).AnyTimes()
 			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
 			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f0_0", HardwareAddr: vf0Mac})
 			netlinkLibMock.EXPECT().LinkByIndex(42).Return(vf0LinkMock, nil).AnyTimes()
 			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
-			hostMock.EXPECT().GetPhysPortName("enp216s0f0np0").Return("p0", nil)
-			hostMock.EXPECT().GetPhysSwitchID("enp216s0f0np0").Return("7cfe90ff2cc0", nil)
-			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
+			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.2", "vf_param", "enabled").Return(nil).After(vfConfigured)
 			hostMock.EXPECT().LoadUdevRules().Return(nil)
-
-			// Devlink params should be applied after all configuration is complete
-			hostMock.EXPECT().SetDevlinkDeviceParam("0000:d8:00.0", "esw_multiport", "true").Return(nil)
 
 			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
 
@@ -1224,7 +1641,8 @@ var _ = Describe("SRIOV", func() {
 					EswitchMode: "switchdev",
 					DevlinkParams: sriovnetworkv1.DevlinkParams{
 						Params: []sriovnetworkv1.DevlinkParam{
-							{Name: "esw_multiport", Value: "true", ApplyOn: "PF"},
+							{Name: "esw_multiport", Value: "true", ApplyOn: "pf"},
+							{Name: "vf_param", Value: "enabled", ApplyOn: "vf"},
 						},
 					},
 					VfGroups: []sriovnetworkv1.VfGroup{


### PR DESCRIPTION
## Summary

Continues and supersedes #194, originally opened by @e0ne.

This change distinguishes PF-targeted and VF-targeted devlink parameters, reconciles each parameter against the status of its actual target, and applies it at the correct point in SR-IOV configuration.

## Why the change is needed

If esw_multiport devlink param is set after VFs are created, it creates "gaps" in infiniband uverb char devices names, e.g.:

* uverb0
* uverb4
* uverb5
* uverb6
* uverb7

This happens because PFs, combined under multiport, share the same single RDMA device.

This leads to a problem when creating pods, that allocate one of those VFs. When RDMA device is moved to a different network namespace, its uverb device gets recreates, and the name of the new device will have the first available index (filling the gap of the missing uverbs). Kubelet doesn't expect the name of the mounted resource to change and fails.

Creating VFs after setting esw_multiport allows us to avoid this problem

## Behavior

- Treat `ApplyOn: PF` (and the empty default) as a PF parameter and `ApplyOn: VF` as a VF parameter, case-insensitively.
- Discover devlink state for the PF even when it has no VFs, and discover devlink state for each VF.
- Reconcile parameters by name, target, and value so a target change or value drift is detected.
- Avoid rewriting PF parameters that already have the desired value.
- Skip PF and VF devlink mutations for externally managed interfaces.

When a PF-targeted value is missing or differs from the desired value, all participating PFs use a batch-wide barrier:

1. Remove existing VFs and wait until stale VF links disappear.
2. Move every participating PF to its requested eSwitch mode.
3. Apply all changed PF parameters.
4. Recreate and configure VFs.
5. Apply VF-targeted parameters after VF configuration.

`flow_steering_mode` remains the exception: after VF removal it is applied in legacy mode, before the PF moves to switchdev.

VF-only drift does not invoke PF/HW configuration. Ordinary VF-count or eSwitch-mode changes without PF-parameter drift retain the existing mlx5/ICE driver-specific sequencing, including the mlx5 create-before-switchdev compatibility path.

Both serial and parallel NIC configuration implement the same phases. A failed prepare/apply/completion phase aborts the batch and resets every PF-parameter participant that was prepared.
```

+---------------------------+--------------------------------------------------+--------------------------------------------------+
| Phase                     | Before (network-operator-26.7.x)                 | After (pr-200)                                   |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 1. HW prep                | configureHWOptionsForSwitchdev: HW TC offload    | Same                                             |
|                           | + flow_steering_mode (switchdev only)            |                                                  |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 2. Eswitch mode           | Set inside setEswitchModeAndNumVFs together      | Set in preparePFForVFCreation, separated from    |
|                           | with VF creation, driver-specific                | VF creation, direct SetNicSriovMode              |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 3. PF devlink params      | Applied after VF bind/unbind — last step         | Applied before VF creation — dedicated Pass 2,   |
|                           | in ConfigSriovInterfaces                         | only when PFParamsChanged=true                   |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 4. Create VFs             | mlx5: always created in legacy mode first,       | PFParamsChanged path: VFs created after          |
|                           | then eswitch switched to switchdev.              | switchdev is already set (no legacy              |
|                           | ice: mode set first, then VFs created            | intermediate). PFConfigChanged-only path:        |
|                           |                                                  | preserves old driver-specific behavior           |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 5. Unbind / Bind VFs      | configSriovVFDevices                             | Same                                             |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
| 6. VF devlink params      | Together with PF params, after bind/unbind       | After bind/unbind, separate                      |
|                           |                                                  | applyDevlinkVfParams call                        |
+---------------------------+--------------------------------------------------+--------------------------------------------------+
```