### PR TITLE
mellanox: enable DDI on VFs via VFConfigHook

### DIFF
--- a/Dockerfile.sriov-network-config-daemon-stig
+++ b/Dockerfile.sriov-network-config-daemon-stig
@@ -1,13 +1,35 @@
+ARG BASE_IMAGE_DOCA_FULL_RT_HOST
 ARG UBUNTU_STIG_BASE_IMAGE
 
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 ARG GOPROXY
+ARG TARGETARCH
 ENV GOPROXY=$GOPROXY
 
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
-RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
+RUN GOARCH=${TARGETARCH} make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
+
+# Build doca_mgmt_data_direct and collect its DOCA runtime libraries so they
+# can be dropped into the STIG image which has no DOCA runtime of its own.
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev} AS doca-builder
+
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated \
+        pkg-config meson ninja-build gcc \
+        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
+    ninja -C /tmp/ddi-build && \
+    cp /tmp/ddi-build/doca_mgmt_data_direct /usr/bin/ && \
+    rm -rf /tmp/ddi-build
+
+# Collect DOCA runtime shared libraries (preserving symlinks) into a single
+# directory so they can be COPY'd into the STIG final stage.
+RUN mkdir -p /doca-dist && \
+    find /usr -name "libdoca*.so*" -exec cp -a {} /doca-dist/ \;
 
 FROM $UBUNTU_STIG_BASE_IMAGE
 # We have to ensure that pciutils is installed. These packages are needed for mstfwreset to succeed.
@@ -30,6 +52,13 @@ RUN case ${TARGETARCH} in \
 RUN rm -f /usr/bin/mstconfig /usr/bin/mstfwreset
 RUN ln -s $(which mlxconfig) /usr/bin/mstconfig
 RUN ln -s $(which mlxfwreset) /usr/bin/mstfwreset
+
+# Install doca_mgmt_data_direct and its DOCA runtime libraries from the
+# doca-builder stage.  The STIG base image has no DOCA runtime, so the libs
+# are placed under /usr/lib/doca/ and registered via ldconfig.
+COPY --from=doca-builder /usr/bin/doca_mgmt_data_direct /usr/bin/
+COPY --from=doca-builder /doca-dist/ /usr/lib/doca/
+RUN echo "/usr/lib/doca" > /etc/ld.so.conf.d/doca.conf && ldconfig
 
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"

--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -25,7 +25,22 @@ WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.2.1-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev}
+
+# Install DOCA dev packages while the internal NVIDIA apt sources are still available.
+# doca-samples provides the mgmt_data_direct source tree;
+# libdoca-sdk-mgmt-dev and libdoca-sdk-argp-dev provide the headers meson needs.
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated \
+        pkg-config meson ninja-build gcc \
+        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Build doca_mgmt_data_direct from DOCA samples.
+RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
+    ninja -C /tmp/ddi-build && \
+    cp /tmp/ddi-build/doca_mgmt_data_direct /usr/bin/ && \
+    rm -rf /tmp/ddi-build
 
 # Drop NVIDIA-internal apt sources baked into staging DOCA base images so the
 # build works from public CI (GitHub Actions). mstflint then resolves from Ubuntu.

--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -188,6 +188,8 @@ spec:
             value: "{{.ClusterType}}"
           - name: DEV_MODE
             value: "{{.DevMode}}"
+          - name: VF_CONFIG_HOOK_ENABLED
+            value: "{{.VFConfigHookEnabled}}"
           {{- if .UseExternalDrainer }}
           - name: USE_EXTERNAL_DRAINER
             value: "{{.UseExternalDrainer}}"

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -308,6 +308,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(ctx context.Context,
 	data.Data["ClusterType"] = vars.ClusterType
 	data.Data["DevMode"] = os.Getenv("DEV_MODE")
 	data.Data["UseExternalDrainer"] = vars.UseExternalDrainer
+	data.Data["VFConfigHookEnabled"] = os.Getenv("VF_CONFIG_HOOK_ENABLED")
 	data.Data["ImagePullSecrets"] = GetImagePullSecrets()
 	if dc.Spec.ConfigurationMode == sriovnetworkv1.SystemdConfigurationMode {
 		data.Data["UsedSystemdMode"] = true

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -215,6 +215,18 @@ func (mr *MockHostHelpersInterfaceMockRecorder) ConfigSriovDevicesVirtual(storeM
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovDevicesVirtual", reflect.TypeOf((*MockHostHelpersInterface)(nil).ConfigSriovDevicesVirtual), storeManager, interfaces, ifaceStatuses)
 }
 
+// SetVFConfigHook mocks base method.
+func (m *MockHostHelpersInterface) SetVFConfigHook(hook types.VFConfigHook) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVFConfigHook", hook)
+}
+
+// SetVFConfigHook indicates an expected call of SetVFConfigHook.
+func (mr *MockHostHelpersInterfaceMockRecorder) SetVFConfigHook(hook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVFConfigHook", reflect.TypeOf((*MockHostHelpersInterface)(nil).SetVFConfigHook), hook)
+}
+
 // ConfigSriovInterfaces mocks base method.
 func (m *MockHostHelpersInterface) ConfigSriovInterfaces(storeManager store.ManagerInterface, interfaces []v1.Interface, ifaceStatuses []v1.InterfaceExt, skipVFConfiguration bool) error {
 	m.ctrl.T.Helper()
@@ -1153,6 +1165,27 @@ func (mr *MockHostHelpersInterfaceMockRecorder) RunCommand(arg0 any, arg1 ...any
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockHostHelpersInterface)(nil).RunCommand), varargs...)
+}
+
+// RunCommandWithEnv mocks base method.
+func (m *MockHostHelpersInterface) RunCommandWithEnv(arg0 []string, arg1 string, arg2 ...string) (string, string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunCommandWithEnv", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RunCommandWithEnv indicates an expected call of RunCommandWithEnv.
+func (mr *MockHostHelpersInterfaceMockRecorder) RunCommandWithEnv(arg0 any, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommandWithEnv", reflect.TypeOf((*MockHostHelpersInterface)(nil).RunCommandWithEnv), varargs...)
 }
 
 // SaveLastPfAppliedStatus mocks base method.

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -69,6 +69,7 @@ type sriov struct {
 	sriovnetLib      sriovnetPkg.SriovnetLib
 	ghwLib           ghwPkg.GHWLib
 	bridgeHelper     types.BridgeInterface
+	vfConfigHook     types.VFConfigHook
 }
 
 func New(utilsHelper utils.CmdInterface,
@@ -94,6 +95,10 @@ func New(utilsHelper utils.CmdInterface,
 		ghwLib:           ghwLib,
 		bridgeHelper:     bridgeHelper,
 	}
+}
+
+func (s *sriov) SetVFConfigHook(hook types.VFConfigHook) {
+	s.vfConfigHook = hook
 }
 
 func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
@@ -796,6 +801,11 @@ func (s *sriov) configSriovVFDevices(iface *sriovnetworkv1.Interface) error {
 
 			if err = s.kernelHelper.UnbindDriverIfNeeded(addr, group.IsRdma); err != nil {
 				return err
+			}
+			if s.vfConfigHook != nil && vars.VFConfigHookEnabled {
+				if err := s.vfConfigHook.OnVFUnbound(iface, addr, group); err != nil {
+					return err
+				}
 			}
 			// we set eswitch mode before this point and if the desired mode (and current at this point)
 			// is legacy, then VDPA device is already automatically disappeared,

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -185,6 +185,18 @@ func (mr *MockHostManagerInterfaceMockRecorder) ConfigSriovDevicesVirtual(storeM
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovDevicesVirtual", reflect.TypeOf((*MockHostManagerInterface)(nil).ConfigSriovDevicesVirtual), storeManager, interfaces, ifaceStatuses)
 }
 
+// SetVFConfigHook mocks base method.
+func (m *MockHostManagerInterface) SetVFConfigHook(hook types.VFConfigHook) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVFConfigHook", hook)
+}
+
+// SetVFConfigHook indicates an expected call of SetVFConfigHook.
+func (mr *MockHostManagerInterfaceMockRecorder) SetVFConfigHook(hook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVFConfigHook", reflect.TypeOf((*MockHostManagerInterface)(nil).SetVFConfigHook), hook)
+}
+
 // ConfigSriovInterfaces mocks base method.
 func (m *MockHostManagerInterface) ConfigSriovInterfaces(storeManager store.ManagerInterface, interfaces []v1.Interface, ifaceStatuses []v1.InterfaceExt, skipVFConfiguration bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -168,6 +168,17 @@ type SriovInterface interface {
 	// ConfigSriovDevicesVirtual configure virtual functions for virtual environments with the desired configuration
 	ConfigSriovDevicesVirtual(storeManager store.ManagerInterface, interfaces []sriovnetworkv1.Interface,
 		ifaceStatuses []sriovnetworkv1.InterfaceExt) error
+	// SetVFConfigHook registers an optional per-VF hook called after a VF is unbound, before rebinding.
+	// Vendor plugins use this to inject vendor-specific per-VF logic; the default (nil) is a no-op.
+	SetVFConfigHook(hook VFConfigHook)
+}
+
+// VFConfigHook is an optional per-VF hook called after a VF is unbound, before rebinding.
+// Implementations are registered by vendor plugins via SetVFConfigHook; nil means no-op.
+type VFConfigHook interface {
+	// OnVFUnbound is called after a VF has been unbound from its driver.
+	// iface is the PF interface spec, vfPciAddr is the VF PCI address, group is the matched VfGroup.
+	OnVFUnbound(iface *sriovnetworkv1.Interface, vfPciAddr string, group *sriovnetworkv1.VfGroup) error
 }
 
 type UdevInterface interface {

--- a/pkg/platform/baremetal/baremetal_test.go
+++ b/pkg/platform/baremetal/baremetal_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Baremetal", func() {
 		hostHelper = mock_helper.NewMockHostHelpersInterface(mockCtrl)
 		hostHelper.EXPECT().GetCurrentKernelArgs().Return("", nil).AnyTimes()
 		hostHelper.EXPECT().IsKernelArgsSet(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		hostHelper.EXPECT().SetVFConfigHook(gomock.Any()).AnyTimes()
 
 		var err error
 		bm, err = New(hostHelper)

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -45,6 +45,25 @@ var mellanoxNicsSpec map[string]sriovnetworkv1.Interface
 func NewMellanoxPlugin(helpers helper.HostHelpersInterface) (plugin.VendorPlugin, error) {
 	mellanoxNicsStatus = map[string]map[string]sriovnetworkv1.InterfaceExt{}
 
+	// In DaemonSet mode the daemon chroots to /host before calling
+	// ConfigSriovInterfaces, making the container's doca_mgmt_data_direct binary
+	// and its DOCA-specific shared libraries inaccessible.  Stage them to the host
+	// filesystem now (before any chroot) so that the VF hook can run the binary
+	// directly from the host filesystem without any process-wide chroot flip.
+	//
+	// Staging is best-effort: if it fails (e.g. non-NVIDIA image without the
+	// binary) the hook is still registered but execDDI will soft-skip when the
+	// binary is not found at the staged path.
+	if !vars.UsingSystemdMode {
+		if err := ensureDDIStaged(); err != nil {
+			log.Log.Error(err, "MellanoxPlugin: failed to stage DDI assets; DDI will be skipped at runtime")
+		}
+	}
+	helpers.SetVFConfigHook(&MellanoxVFHook{
+		kernelHelper: helpers,
+		utilsHelper:  helpers,
+	})
+
 	return &MellanoxPlugin{
 		PluginName: PluginName,
 		helpers:    helpers,

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -50,6 +50,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 	BeforeEach(func() {
 		testCtrl = gomock.NewController(GinkgoT())
 		h = mock_helper.NewMockHostHelpersInterface(testCtrl)
+		h.EXPECT().SetVFConfigHook(gomock.Any())
 		m, err = NewMellanoxPlugin(h)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/plugins/mellanox/vf_hook.go
+++ b/pkg/plugins/mellanox/vf_hook.go
@@ -1,0 +1,311 @@
+// Copyright 2025 sriov-network-device-plugin authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mellanox
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/types"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
+)
+
+const (
+	ddiBinaryName = "doca_mgmt_data_direct"
+	// Source paths inside the container image.
+	ddiBinarySrc = "/usr/bin/" + ddiBinaryName
+	// Destination paths used after the daemon chroots to /host.
+	// stageDDIAssets copies from the container filesystem to these host paths
+	// (prefixed with /host) at plugin init, before any chroot takes place.
+	ddiStagingBase      = "/var/lib/sriov/ddi"
+	ddiStagedBinaryPath = ddiStagingBase + "/" + ddiBinaryName
+	ddiStagedLibPath    = ddiStagingBase + "/lib"
+)
+
+// MellanoxVFHook implements types.VFConfigHook for Mellanox/NVIDIA NICs.
+// It enables DDI (Data Direct Interface) on VFs that belong to an interface
+// configured with flow_steering_mode=hmfs (Spectrum-X).
+type MellanoxVFHook struct {
+	kernelHelper types.KernelInterface
+	utilsHelper  utils.CmdInterface
+}
+
+// OnVFUnbound is called after a VF has been unbound from its driver.
+// If the PF interface is configured with flow_steering_mode=hmfs, DDI is
+// enabled on the VF.
+func (h *MellanoxVFHook) OnVFUnbound(
+	iface *sriovnetworkv1.Interface,
+	vfPciAddr string,
+	_ *sriovnetworkv1.VfGroup,
+) error {
+	if !hasDDIRequired(iface) {
+		return nil
+	}
+
+	pfPciAddr := iface.PciAddress
+	fwctlDir := filepath.Join(consts.SysBusPciDevices, pfPciAddr, "fwctl")
+
+	if _, err := os.Stat(fwctlDir); os.IsNotExist(err) {
+		// Attempt to load the fwctl kernel modules.  Treat any load failure as
+		// a soft-skip: a missing module means this kernel was built without
+		// CONFIG_FWCTL (or lacks the mlx5 fwctl driver), so DDI is not
+		// available — same outcome as the sysfs entry being absent after a
+		// successful load.  Hard-failing here would abort VF configuration for
+		// the entire PF on any standard kernel that does not carry fwctl.
+		if err := h.kernelHelper.LoadKernelModule("fwctl"); err != nil {
+			log.Log.Info("MellanoxVFHook: fwctl module not available, skipping DDI",
+				"pf", pfPciAddr, "reason", err)
+			return nil
+		}
+		if err := h.kernelHelper.LoadKernelModule("mlx5_fwctl"); err != nil {
+			log.Log.Info("MellanoxVFHook: mlx5_fwctl module not available, skipping DDI",
+				"pf", pfPciAddr, "reason", err)
+			return nil
+		}
+		if _, err := os.Stat(fwctlDir); os.IsNotExist(err) {
+			log.Log.Info("MellanoxVFHook: fwctl sysfs entry absent after module load, NIC does not support DDI",
+				"pf", pfPciAddr)
+			return nil
+		}
+	}
+
+	return h.execDDI(vfPciAddr)
+}
+
+// execDDI runs doca_mgmt_data_direct to enable DDI on the given VF.
+//
+// In DaemonSet mode the binary and its DOCA-specific shared libraries are
+// staged to the host filesystem by stageDDIAssets (called at plugin init,
+// before any chroot).  execDDI runs the staged binary directly — no chroot
+// manipulation is needed and vars.InChroot is never touched.
+//
+// In systemd mode the binary is expected on $PATH.
+func (h *MellanoxVFHook) execDDI(vfPciAddr string) error {
+	if vars.InChroot {
+		// DaemonSet mode: binary and DOCA libs live at known host paths.
+		stdout, stderr, err := h.utilsHelper.RunCommandWithEnv(
+			[]string{"LD_LIBRARY_PATH=" + ddiStagedLibPath},
+			ddiStagedBinaryPath,
+			"set", "--vf-pci-addr", vfPciAddr, "--enabled", "true")
+		return ddiResult(stdout, stderr, err, vfPciAddr)
+	}
+	// Systemd mode: binary is on $PATH.
+	stdout, stderr, err := h.utilsHelper.RunCommand(ddiBinaryName,
+		"set", "--vf-pci-addr", vfPciAddr, "--enabled", "true")
+	return ddiResult(stdout, stderr, err, vfPciAddr)
+}
+
+// ddiResult interprets the output from doca_mgmt_data_direct and converts
+// known non-fatal conditions (binary absent, device unsupported) into nil.
+func ddiResult(stdout, stderr string, err error, vfPciAddr string) error {
+	if err == nil {
+		log.Log.Info("MellanoxVFHook: DDI enabled", "vf", vfPciAddr)
+		return nil
+	}
+	// Handle both $PATH lookup failure (exec.ErrNotFound) and absolute-path
+	// not-found (os.ErrNotExist) — the latter occurs when staging was skipped or
+	// the staged binary was removed.
+	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+		log.Log.Info("MellanoxVFHook: doca_mgmt_data_direct not found, skipping DDI",
+			"vf", vfPciAddr)
+		return nil
+	}
+	combined := stdout + stderr
+	if strings.Contains(combined, "not supported") ||
+		strings.Contains(combined, "DOCA_ERROR_NOT_SUPPORTED") ||
+		strings.Contains(combined, "VHCA ID as function ID is not supported") ||
+		// PF1 on CX8 in esw_multiport (Spectrum-X) does not expose a DOCA
+		// fwctl device for DDI; the binary exits 1 with these messages.
+		strings.Contains(combined, "Matching device not found") ||
+		strings.Contains(combined, "Requested Resource Not Found") {
+		log.Log.Info("MellanoxVFHook: DDI not supported on device, skipping",
+			"vf", vfPciAddr)
+		return nil
+	}
+	// A dynamic-linker error means the staged libraries are absent or
+	// incomplete.  Treat this as a soft-skip so that a staging failure on one
+	// boot does not abort VF configuration for the whole PF.
+	if strings.Contains(combined, "error while loading shared libraries") ||
+		strings.Contains(combined, "cannot open shared object file") {
+		log.Log.Info("MellanoxVFHook: doca_mgmt_data_direct missing shared libraries, skipping DDI",
+			"vf", vfPciAddr, "output", combined)
+		return nil
+	}
+	// Belt-and-suspenders: some failure modes exit non-zero with no output
+	// at all (e.g. very early binary errors).  Treat silent failure as a
+	// soft-skip rather than a hard error to avoid infinite reconcile loops.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && combined == "" {
+		log.Log.Info("MellanoxVFHook: doca_mgmt_data_direct exited non-zero with no output, skipping DDI",
+			"vf", vfPciAddr, "exitCode", exitErr.ExitCode())
+		return nil
+	}
+	return fmt.Errorf("MellanoxVFHook: doca_mgmt_data_direct set failed for %s: %w\n%s",
+		vfPciAddr, err, combined)
+}
+
+// hasDDIRequired returns true when the interface is configured for Spectrum-X
+// HMFS, which requires DDI to be enabled on its VFs.
+func hasDDIRequired(iface *sriovnetworkv1.Interface) bool {
+	for _, p := range iface.DevlinkParams.Params {
+		if p.Name == consts.DevlinkParamFlowSteeringMode &&
+			p.Value == consts.FlowSteeringModeHmfs {
+			return true
+		}
+	}
+	return false
+}
+
+// systemLibBasenames are well-known glibc / GCC runtime libraries that are
+// always present on the host OS and must not be overridden by container copies.
+var systemLibBasenames = map[string]bool{
+	"libc.so.6": true, "libm.so.6": true, "libdl.so.2": true,
+	"librt.so.1": true, "libpthread.so.0": true, "libutil.so.1": true,
+}
+
+// ddiStageOnce ensures stageDDIAssets is executed at most once even when
+// NewMellanoxPlugin is called multiple times (once per detected NIC).
+var (
+	ddiStageOnce sync.Once
+	errDDIStage  error
+)
+
+// ensureDDIStaged calls stageDDIAssets exactly once and caches the result.
+func ensureDDIStaged() error {
+	ddiStageOnce.Do(func() {
+		errDDIStage = stageDDIAssets()
+	})
+	return errDDIStage
+}
+
+// stageDDIAssets copies doca_mgmt_data_direct and every non-system shared
+// library it transitively depends on from the container filesystem into the
+// host filesystem under /host/var/lib/sriov/ddi/.
+// This must be called before any chroot.
+//
+// ldd is run against the binary while still in the container context to
+// obtain the fully-resolved path of every dependency.  copyFileMode opens
+// each path with os.Open (which follows symlinks), so SONAME symlinks are
+// materialized as independent real files in the staging directory.  This
+// guarantees the dynamic linker can satisfy every SONAME at runtime without
+// any LD_LIBRARY_PATH guessing.
+func stageDDIAssets() error {
+	if _, err := os.Stat(ddiBinarySrc); err != nil {
+		return fmt.Errorf("stageDDIAssets: %s not found in container image: %w", ddiBinaryName, err)
+	}
+
+	dstDir := filepath.Join(consts.Host, ddiStagingBase)
+	dstLib := filepath.Join(consts.Host, ddiStagedLibPath)
+	if err := os.MkdirAll(dstLib, 0755); err != nil {
+		return fmt.Errorf("stageDDIAssets: cannot create lib staging dir: %w", err)
+	}
+
+	if err := copyFileMode(ddiBinarySrc, filepath.Join(dstDir, ddiBinaryName), 0755); err != nil {
+		return fmt.Errorf("stageDDIAssets: cannot copy binary: %w", err)
+	}
+
+	if err := stageDDILibs(dstLib); err != nil {
+		return fmt.Errorf("stageDDIAssets: library staging failed; DDI binary will not run: %w", err)
+	}
+	return nil
+}
+
+// stageDDILibs uses ldd to enumerate every shared library that
+// doca_mgmt_data_direct transitively requires and copies the non-system ones
+// into dstLib.
+//
+// ldd is invoked while the process is still in the container root, so paths
+// resolve against container-image libraries — the exact versions the binary
+// was linked against.  Only the fundamental glibc libraries that are always
+// available on the host are excluded (see systemLibBasenames).
+func stageDDILibs(dstLib string) error {
+	// ldd output lines look like one of:
+	//   libfoo.so.2 => /usr/lib/x86_64-linux-gnu/libfoo.so.2 (0x7f...)
+	//   linux-vdso.so.1 (0x7ffd...)           ← virtual; no file
+	//   /lib64/ld-linux-x86-64.so.2 (0x7f...) ← ELF interpreter; skip
+	out, err := exec.Command("ldd", ddiBinarySrc).Output()
+	if err != nil {
+		return fmt.Errorf("ldd %s: %w", ddiBinarySrc, err)
+	}
+
+	staged := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		// Skip vdso, ELF interpreter, and empty lines.
+		if line == "" || strings.Contains(line, "linux-vdso") ||
+			strings.HasPrefix(line, "/lib") || strings.HasPrefix(line, "/lib64") {
+			continue
+		}
+
+		idx := strings.Index(line, "=>")
+		if idx < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(line[idx+2:])
+		// Remove trailing " (0x...)" load address.
+		if sp := strings.Index(rest, " "); sp >= 0 {
+			rest = rest[:sp]
+		}
+		if rest == "" || rest == "not found" {
+			continue
+		}
+
+		name := filepath.Base(rest)
+		if systemLibBasenames[name] {
+			continue
+		}
+
+		dst := filepath.Join(dstLib, name)
+		if err := copyFileMode(rest, dst, 0644); err != nil {
+			log.Log.Error(err, "stageDDIAssets: failed to copy library", "lib", rest)
+			continue
+		}
+		staged++
+	}
+	log.Log.Info("stageDDIAssets: staged DDI libraries", "count", staged, "dst", dstLib)
+	return nil
+}
+
+func copyFileMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/pkg/utils/mock/mock_utils.go
+++ b/pkg/utils/mock/mock_utils.go
@@ -89,3 +89,24 @@ func (mr *MockCmdInterfaceMockRecorder) RunCommand(arg0 any, arg1 ...any) *gomoc
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockCmdInterface)(nil).RunCommand), varargs...)
 }
+
+// RunCommandWithEnv mocks base method.
+func (m *MockCmdInterface) RunCommandWithEnv(arg0 []string, arg1 string, arg2 ...string) (string, string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunCommandWithEnv", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RunCommandWithEnv indicates an expected call of RunCommandWithEnv.
+func (mr *MockCmdInterfaceMockRecorder) RunCommandWithEnv(arg0 any, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommandWithEnv", reflect.TypeOf((*MockCmdInterface)(nil).RunCommandWithEnv), varargs...)
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,6 +41,9 @@ const (
 type CmdInterface interface {
 	Chroot(string) (func() error, error)
 	RunCommand(string, ...string) (string, string, error)
+	// RunCommandWithEnv runs a command with additional environment variables appended to the
+	// current process environment.  env entries take the form "KEY=VALUE".
+	RunCommandWithEnv(env []string, command string, args ...string) (string, string, error)
 	HTTPGetFetchData(string) (string, error)
 }
 
@@ -106,10 +109,19 @@ func (u *utilsHelper) HTTPGetFetchData(url string) (string, error) {
 
 // RunCommand runs a command
 func (u *utilsHelper) RunCommand(command string, args ...string) (string, string, error) {
+	return u.RunCommandWithEnv(nil, command, args...)
+}
+
+// RunCommandWithEnv runs a command with extra environment variables appended to
+// the current process environment.  env entries take the form "KEY=VALUE".
+func (u *utilsHelper) RunCommandWithEnv(env []string, command string, args ...string) (string, string, error) {
 	log.Log.Info("RunCommand()", "command", command, "args", args)
 	var stdout, stderr bytes.Buffer
 
 	cmd := exec.Command(command, args...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -105,6 +105,11 @@ var (
 	// UseExternalDrainer controls if SRIOV operator will use an external drainer
 	// for draining nodes or its internal drain controller (default)
 	UseExternalDrainer bool
+
+	// VFConfigHookEnabled controls whether the VFConfigHook is invoked during VF
+	// configuration. Set VF_CONFIG_HOOK_ENABLED=false on the operator deployment
+	// to disable. Defaults to true when unset.
+	VFConfigHookEnabled bool
 )
 
 func init() {
@@ -129,6 +134,7 @@ func init() {
 	FeatureGate = featuregate.New()
 
 	UseExternalDrainer = os.Getenv("USE_EXTERNAL_DRAINER") == "true"
+	VFConfigHookEnabled = os.Getenv("VF_CONFIG_HOOK_ENABLED") != "false"
 }
 
 func GetPlatformType(providerID string) consts.PlatformTypes {


### PR DESCRIPTION
Add a VFConfigHook extension point to SriovInterface that vendor plugins can register to inject per-VF logic after unbind. The Mellanox plugin registers MellanoxVFHook, which enables DDI (Data Direct Interface) on VFs whose PF is configured with flow_steering_mode=hmfs (Spectrum-X).

The hook loads the fwctl/mlx5_fwctl kernel modules if absent, then calls doca_mgmt_data_direct set. Unsupported NICs (no fwctl sysfs entry or firmware rejection) are soft-skipped without failing the SR-IOV flow.

doca_mgmt_data_direct is compiled from the DOCA samples bundled in the base image and copied into the NVIDIA config-daemon container image. No CRD changes are required; the existing flow_steering_mode=hmfs devlink param serves as the DDI opt-in signal.