### PR TITLE
Mount writable MFT state in config daemon

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -205,6 +205,8 @@ spec:
             mountPath: /host
           - name: tmp
             mountPath: /tmp
+          - name: mft-state
+            mountPath: /var/lib/mft
         lifecycle:
           preStop:
             exec:
@@ -221,4 +223,6 @@ spec:
           path: /etc/os-release
           type: File
       - name: tmp
+        emptyDir: {}
+      - name: mft-state
         emptyDir: {}


### PR DESCRIPTION
## Summary
- mount a dedicated emptyDir at /var/lib/mft in the sriov-network-config-daemon container
- keep readOnlyRootFilesystem enabled while allowing the NVIDIA/DOCA reset tooling to persist its runtime state

## Why
The NVIDIA config-daemon image replaces the mstfwreset compatibility command with the mlxfwreset implementation. That path can write under /var/lib/mft. With the config daemon root filesystem mounted read-only, firmware reset can fail before node reboot with:

```
-E- [Errno 30] Read-only file system: '/var/lib/mft'
```

The upstream CentOS/mstflint image does not reproduce this because its mstfwreset implementation does not use /var/lib/mft. This change is needed for the NVIDIA/DOCA image used by this branch while keeping the container root filesystem read-only.

## Validation
- go test ./pkg/render
- Built and pushed linux/amd64 operator image from this branch: harbor.mellanox.com/cloud-orchestration-dev/sriov-network-operator:network-operator-26.7.x-mft-state-amd64
- Built and checked the upstream-Dockerfile config-daemon image separately; it uses mstflint mstfwreset and does not reproduce the /var/lib/mft failure
- Runtime verified on cluster by deploying the fixed operator image and confirming the NVIDIA-image mstfwreset flow works
