### PR TITLE
fix: build doca_mgmt_data_direct from DOCA devel image

### DIFF
--- a/Dockerfile.sriov-network-config-daemon-stig
+++ b/Dockerfile.sriov-network-config-daemon-stig
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_DOCA_FULL_RT_HOST
+ARG BASE_IMAGE_DOCA_DEVEL_HOST
 ARG UBUNTU_STIG_BASE_IMAGE
 
 FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
@@ -13,13 +13,7 @@ RUN GOARCH=${TARGETARCH} make _build-sriov-network-config-daemon BIN_PATH=build/
 
 # Build doca_mgmt_data_direct and collect its DOCA runtime libraries so they
 # can be dropped into the STIG image which has no DOCA runtime of its own.
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev} AS doca-builder
-
-RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
-    apt-get install -y --allow-unauthenticated \
-        pkg-config meson ninja-build gcc \
-        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM ${BASE_IMAGE_DOCA_DEVEL_HOST:-nvcr.io/nvstaging/doca/doca:devel-3.5.0071-host-dev} AS doca-builder
 
 RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
     ninja -C /tmp/ddi-build && \

--- a/Dockerfile.sriov-network-config-daemon.nvidia
+++ b/Dockerfile.sriov-network-config-daemon.nvidia
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE_DOCA_FULL_RT_HOST
+ARG BASE_IMAGE_DOCA_DEVEL_HOST
 
 FROM golang:1.25 AS builder
 
@@ -25,22 +26,17 @@ WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0036-host-dev}
+# Build doca_mgmt_data_direct from the DOCA devel image, which already ships
+# samples, headers, and build tools. Avoid apt installs from doca-repo-prod,
+# which is not reachable from public CI runners.
+FROM ${BASE_IMAGE_DOCA_DEVEL_HOST:-nvcr.io/nvstaging/doca/doca:devel-3.5.0071-host-dev} AS doca-builder
 
-# Install DOCA dev packages while the internal NVIDIA apt sources are still available.
-# doca-samples provides the mgmt_data_direct source tree;
-# libdoca-sdk-mgmt-dev and libdoca-sdk-argp-dev provide the headers meson needs.
-RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
-    apt-get install -y --allow-unauthenticated \
-        pkg-config meson ninja-build gcc \
-        doca-samples libdoca-sdk-mgmt-dev libdoca-sdk-argp-dev && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Build doca_mgmt_data_direct from DOCA samples.
 RUN meson setup /opt/mellanox/doca/samples/doca_mgmt/mgmt_data_direct /tmp/ddi-build && \
     ninja -C /tmp/ddi-build && \
     cp /tmp/ddi-build/doca_mgmt_data_direct /usr/bin/ && \
     rm -rf /tmp/ddi-build
+
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0071-host-dev}
 
 # Drop NVIDIA-internal apt sources baked into staging DOCA base images so the
 # build works from public CI (GitHub Actions). mstflint then resolves from Ubuntu.
@@ -62,6 +58,7 @@ RUN ln -s $(which mlxfwreset) /usr/bin/mstfwreset
 
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
+COPY --from=doca-builder /usr/bin/doca_mgmt_data_direct /usr/bin/
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/
 COPY bindata /bindata
 # copy project sources into the container


### PR DESCRIPTION
CI fails when installing doca-samples and SDK dev packages from doca-repo-prod.nvidia.com, which GHA runners cannot resolve. Build doca_mgmt_data_direct in a separate stage based on the DOCA devel image, which already includes samples, headers, and build tools, then copy the binary into the full-rt runtime image.