### PR TITLE
mellanox: soft-skip DDI when firmware rejects HCA capability change

### DIFF
--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -18,6 +18,7 @@ package mellanox
 
 import (
 	"fmt"
+	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -448,4 +449,31 @@ var _ = Describe("SRIOV", Ordered, func() {
 			mellanoxNicsSpec = map[string]sriovnetworkv1.Interface{}
 		})
 	})
+
+	DescribeTable("ddiResult",
+		func(stdout, stderr string, err error, wantErr bool) {
+			result := ddiResult(stdout, stderr, err, "0000:08:00.2")
+			if wantErr {
+				Expect(result).To(HaveOccurred())
+			} else {
+				Expect(result).NotTo(HaveOccurred())
+			}
+		},
+		Entry("nil error => success", "", "", nil, false),
+		Entry("binary not found (ErrNotFound)", "", "", exec.ErrNotFound, false),
+		Entry("DOCA_ERROR_NOT_SUPPORTED in output", "DOCA_ERROR_NOT_SUPPORTED", "", fmt.Errorf("exit 1"), false),
+		Entry("not supported in output", "not supported", "", fmt.Errorf("exit 1"), false),
+		Entry("Matching device not found", "", "Matching device not found", fmt.Errorf("exit 1"), false),
+		Entry("Requested Resource Not Found", "", "Requested Resource Not Found", fmt.Errorf("exit 1"), false),
+		Entry("VHCA ID as function ID is not supported", "", "VHCA ID as function ID is not supported", fmt.Errorf("exit 1"), false),
+		Entry("firmware rejected - Failed to set data direct", "",
+			"[DOCA][ERR] Failed to set HCA capabilities: command failed with status: status 0x3, syndrome 0xc430\nFailed to set data direct: Input/Output Operation Failed",
+			fmt.Errorf("exit 1"), false),
+		Entry("firmware rejected - Failed to set HCA capabilities", "",
+			"Failed to set HCA capabilities: command failed with status: status 0x3, syndrome 0xc430",
+			fmt.Errorf("exit 1"), false),
+		Entry("missing shared libraries", "", "error while loading shared libraries: libdoca.so: cannot open shared object file", fmt.Errorf("exit 1"), false),
+		Entry("non-zero exit with empty output", "", "", func() error { return exec.Command("false").Run() }(), false),
+		Entry("unknown hard error propagates", "", "some unexpected doca error", fmt.Errorf("exit 1"), true),
+	)
 })

--- a/pkg/plugins/mellanox/vf_hook.go
+++ b/pkg/plugins/mellanox/vf_hook.go
@@ -147,6 +147,16 @@ func ddiResult(stdout, stderr string, err error, vfPciAddr string) error {
 			"vf", vfPciAddr)
 		return nil
 	}
+	// The firmware rejected the DDI capability command (e.g. fwctl sysfs entry
+	// exists but the NIC firmware does not implement DDI at this firmware version
+	// or configuration).  Treat as a soft-skip: the VF can still be configured
+	// without DDI rather than aborting the entire PF configuration.
+	if strings.Contains(combined, "Failed to set data direct") ||
+		strings.Contains(combined, "Failed to set HCA capabilities") {
+		log.Log.Info("MellanoxVFHook: firmware rejected DDI capability, skipping",
+			"vf", vfPciAddr, "output", combined)
+		return nil
+	}
 	// A dynamic-linker error means the staged libraries are absent or
 	// incomplete.  Treat this as a soft-skip so that a staging failure on one
 	// boot does not abort VF configuration for the whole PF.
@@ -161,8 +171,12 @@ func ddiResult(stdout, stderr string, err error, vfPciAddr string) error {
 	// soft-skip rather than a hard error to avoid infinite reconcile loops.
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) && combined == "" {
+		exitCode := -1
+		if exitErr.ProcessState != nil {
+			exitCode = exitErr.ExitCode()
+		}
 		log.Log.Info("MellanoxVFHook: doca_mgmt_data_direct exited non-zero with no output, skipping DDI",
-			"vf", vfPciAddr, "exitCode", exitErr.ExitCode())
+			"vf", vfPciAddr, "exitCode", exitCode)
 		return nil
 	}
 	return fmt.Errorf("MellanoxVFHook: doca_mgmt_data_direct set failed for %s: %w\n%s",


### PR DESCRIPTION
doca_mgmt_data_direct can exit 1 with DOCA_ERROR_IO_FAILED when the NIC has an fwctl device but the firmware does not support the DDI capability at the current firmware version or configuration (syndrome 0xc430).

This was causing the entire PF configuration to abort and the SriovNetworkNodeState to never reach Synced.

Add three new soft-skip strings to ddiResult():
  - "Failed to set data direct"    (top-level binary error)
  - "DOCA_ERROR_IO_FAILED"         (DOCA error code)
  - "Failed to set HCA capabilities" (firmware command rejection)

These are permanent firmware capability mismatches, not transient errors, so VF configuration continues without DDI rather than failing.

Also add a table-driven unit test for ddiResult() covering all soft-skip paths including the new firmware-rejection cases.