### PR TITLE
fix: avoid systemd SIGBUS and RKE2/k3s boot race in systemd mode

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -139,10 +139,14 @@ spec:
                 cp /usr/share/hwdata/pci.ids /host/usr/share/hwdata/pci.ids
               fi
               mkdir -p /host/var/lib/sriov/
-              cp /usr/bin/sriov-network-config-daemon /host/var/lib/sriov/sriov-network-config-daemon
+              # Copy via a temp file then rename so a running systemd service that still
+              # has the previous inode mmap'd is not truncated in place (SIGBUS).
+              cp /usr/bin/sriov-network-config-daemon /host/var/lib/sriov/sriov-network-config-daemon.new
+              mv -f /host/var/lib/sriov/sriov-network-config-daemon.new /host/var/lib/sriov/sriov-network-config-daemon
               chcon -t bin_t /host/var/lib/sriov/sriov-network-config-daemon || true # Allow systemd to run the file, use pipe true to not failed if the system doesn't have selinux or apparmor enabled
-              cp /bindata/scripts/kargs.sh /host/var/lib/sriov/kargs.sh
-              chcon -t bin_t /host/var/lib/sriov/kargs.sh | true # Allow systemd to run the file, use pipe true to not failed if the system doesn't have selinux or apparmor enabled
+              cp /bindata/scripts/kargs.sh /host/var/lib/sriov/kargs.sh.new
+              mv -f /host/var/lib/sriov/kargs.sh.new /host/var/lib/sriov/kargs.sh
+              chcon -t bin_t /host/var/lib/sriov/kargs.sh || true # Allow systemd to run the file, use pipe true to not failed if the system doesn't have selinux or apparmor enabled
           securityContext:
             privileged: true
           resources:

--- a/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
+++ b/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
@@ -18,7 +18,7 @@ contents: |
   [Unit]
   Description=Configures SRIOV NIC - post network configuration
   After=systemd-networkd-wait-online.service NetworkManager-wait-online.service openvswitch-switch.service sriov-config.service
-  Before=kubelet.service
+  Before=kubelet.service rke2-agent.service rke2-server.service k3s.service k3s-agent.service
 
   [Service]
   Type=oneshot


### PR DESCRIPTION
Copy the host binary and kargs via temp+rename so an in-place cp cannot truncate a running post service. Also order sriov-config-post-network before rke2-agent/rke2-server and k3s units so post finishes before the agent starts pods on non-kubelet.service clusters.